### PR TITLE
Fix compilation with too long constant strings

### DIFF
--- a/jte-jsp-converter/pom.xml
+++ b/jte-jsp-converter/pom.xml
@@ -70,6 +70,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/jte-runtime-cp-test/pom.xml
+++ b/jte-runtime-cp-test/pom.xml
@@ -70,6 +70,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/jte-runtime-test/pom.xml
+++ b/jte-runtime-test/pom.xml
@@ -70,6 +70,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -37,6 +37,12 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void templateWithoutParameters_mrPoo() {
+        givenRawTemplate("\uD83D\uDCA9");
+        thenOutputIs("\uD83D\uDCA9");
+    }
+
+    @Test
     void templateWithoutParametersLong() {
         givenRawTemplate(".".repeat(65536));
         thenOutputIs(".".repeat(65536));

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -49,6 +49,12 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void templateWithoutParametersLongNull() {
+        givenRawTemplate("\u0000".repeat(65536) + "foo");
+        thenOutputIs("\u0000".repeat(65536) + "foo");
+    }
+
+    @Test
     void templateWithoutParametersLongMultibyteOffset0() {
         givenRawTemplate("\uD83D\uDCA9".repeat(65536));
         thenOutputIs("\uD83D\uDCA9".repeat(65536));

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -37,6 +37,48 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void templateWithoutParametersLong() {
+        givenRawTemplate(".".repeat(65536));
+        thenOutputIs(".".repeat(65536));
+    }
+
+    @Test
+    void templateWithoutParametersLongMultibyteOffset0() {
+        givenRawTemplate("\uD83D\uDCA9".repeat(65536));
+        thenOutputIs("\uD83D\uDCA9".repeat(65536));
+    }
+
+    @Test
+    void templateWithoutParametersLongMultibyteOffset1() {
+        givenRawTemplate("." + "\uD83D\uDCA9".repeat(65536));
+        thenOutputIs("." + "\uD83D\uDCA9".repeat(65536));
+    }
+
+    @Test
+    void templateWithoutParametersLongMultibyteOffset2() {
+        givenRawTemplate(".." + "\uD83D\uDCA9".repeat(65536));
+        thenOutputIs(".." + "\uD83D\uDCA9".repeat(65536));
+    }
+
+    @Test
+    void templateWithoutParametersLongMultibyteOffset3() {
+        givenRawTemplate("..." + "\uD83D\uDCA9".repeat(65536));
+        thenOutputIs("..." + "\uD83D\uDCA9".repeat(65536));
+    }
+
+    @Test
+    void templateWithoutParametersLongMultibyteOffset4() {
+        givenRawTemplate("...." + "\uD83D\uDCA9".repeat(65536));
+        thenOutputIs("...." + "\uD83D\uDCA9".repeat(65536));
+    }
+
+    @Test
+    void templateWithoutParametersLongMultibyteOffset5() {
+        givenRawTemplate("....." + "\uD83D\uDCA9".repeat(65536));
+        thenOutputIs("....." + "\uD83D\uDCA9".repeat(65536));
+    }
+
+    @Test
     void helloWorld_lineBreak() {
         givenTemplate("${model.hello}\nWorld");
         thenOutputIs("Hello\nWorld");

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                </configuration>
             </plugin>
 
             <!-- Javadoc -->


### PR DESCRIPTION
Length calculation is based on modified UTF-8.

References:
 - https://github.com/openjdk/jdk/blob/a8a2246158bc53414394b007cbf47413e62d942e/src/java.base/share/classes/java/io/DataOutputStream.java#L351-L358
 - https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.4.7

Fixes #25.