### PR TITLE
Add gradle plugin

### DIFF
--- a/jte-gradle-plugin/pack-gradle-plugin.xml
+++ b/jte-gradle-plugin/pack-gradle-plugin.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly>
+    <id>pack-gradle-plugin</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>.</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+            <includes>
+                <include>gg.jte:jte</include>
+                <include>gg.jte:jte-runtime</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <outputDirectory>.</outputDirectory>
+            <directory>${project.build.outputDirectory}</directory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/jte-gradle-plugin/pom.xml
+++ b/jte-gradle-plugin/pom.xml
@@ -125,6 +125,17 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>gg.jte.gradle</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.3.0</version>
                 <configuration>

--- a/jte-gradle-plugin/pom.xml
+++ b/jte-gradle-plugin/pom.xml
@@ -113,21 +113,20 @@
     </repositories>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
-            <!-- Disable default JAR plugin -->
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-jar</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <appendAssemblyId>false</appendAssemblyId>

--- a/jte-gradle-plugin/pom.xml
+++ b/jte-gradle-plugin/pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jte-gradle-plugin</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>gg.jte</groupId>
+        <artifactId>jte-parent</artifactId>
+        <version>1.6.1-SNAPSHOT</version>
+    </parent>
+
+    <name>jte-gradle-plugin</name>
+    <description>Precompile all jte templates to Java classes during gradle build</description>
+
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>gg.jte</groupId>
+            <artifactId>jte</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-base-services</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-core-api</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-model-core</artifactId>
+            <version>LATEST</version>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-core</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-language-java</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-logging</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.28</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-language-jvm</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-platform-jvm</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-plugins</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-normalization-java</artifactId>
+            <version>LATEST</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>gradle</id>
+            <url>https://repo.gradle.org/gradle/libs-releases-local</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <!-- Disable default JAR plugin -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <archive>
+                        <addMavenDescriptor>true</addMavenDescriptor>
+                        <manifestEntries>
+                            <Automatic-Module-Name>gg.jte.gradle</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                    <descriptors>
+                        <descriptor>pack-gradle-plugin.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/CompilerMojoBase.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/CompilerMojoBase.java
@@ -1,0 +1,35 @@
+package gg.jte.gradle;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public class CompilerMojoBase extends JteTaskBase {
+
+    protected List<Path> compilePath;
+    protected String htmlPolicyClass;
+    protected String[] compileArgs;
+
+    public List<Path> getCompilePath() {
+        return compilePath;
+    }
+
+    public void setCompilePath(List<Path> value) {
+        compilePath = value;
+    }
+
+    public String getHtmlPolicyClass() {
+        return htmlPolicyClass;
+    }
+
+    public void setHtmlPolicyClass(String value) {
+        htmlPolicyClass = value;
+    }
+
+    public String[] getCompileArgs() {
+        return compileArgs;
+    }
+
+    public void setCompileArgs(String[] value) {
+        compileArgs = value;
+    }
+}

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/CompilerMojoTask.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/CompilerMojoTask.java
@@ -1,0 +1,78 @@
+package gg.jte.gradle;
+
+import gg.jte.TemplateEngine;
+import gg.jte.html.HtmlPolicy;
+import gg.jte.resolve.DirectoryCodeResolver;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class CompilerMojoTask extends CompilerMojoBase {
+
+    @TaskAction
+    public void execute() throws URISyntaxException {
+        Logger logger = getLogger();
+        long start = System.nanoTime();
+
+        logger.info("Precompiling jte templates found in " + sourceDirectory);
+
+        TemplateEngine templateEngine = TemplateEngine.create(new DirectoryCodeResolver(sourceDirectory), targetDirectory, contentType);
+        templateEngine.setTrimControlStructures(trimControlStructures);
+        templateEngine.setHtmlTags(htmlTags);
+        templateEngine.setHtmlAttributes(htmlAttributes);
+        if (htmlPolicyClass != null) {
+            templateEngine.setHtmlPolicy(createHtmlPolicy(htmlPolicyClass));
+        }
+        templateEngine.setHtmlCommentsPreserved(htmlCommentsPreserved);
+        templateEngine.setCompileArgs(compileArgs);
+
+        if (compilePath == null) {
+            compilePath = new ArrayList<>();
+        }
+
+        // Somehow it doesn't link the dependencies, so we need to provide the path to jte-runtime and others to make it work
+        compilePath.add(new File(CompilerMojoTask.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toPath());
+
+        int amount;
+        try {
+            templateEngine.cleanAll();
+            amount = templateEngine.precompileAll(compilePath.stream().map(path -> path.toAbsolutePath().toString()).collect(Collectors.toList())).size();
+        } catch (Exception e) {
+            logger.error("Failed to precompile templates.", e);
+
+            throw e;
+        }
+
+        long end = System.nanoTime();
+        long duration = TimeUnit.NANOSECONDS.toSeconds(end - start);
+        logger.info("Successfully precompiled " + amount + " jte file" + (amount == 1 ? "" : "s") + " in " + duration + "s to " + targetDirectory);
+    }
+
+    private HtmlPolicy createHtmlPolicy(String htmlPolicyClass) {
+        try {
+            URLClassLoader projectClassLoader = createProjectClassLoader();
+            Class<?> clazz = projectClassLoader.loadClass(htmlPolicyClass);
+            return (HtmlPolicy) clazz.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to instantiate custom HtmlPolicy " + htmlPolicyClass, e);
+        }
+    }
+
+    private URLClassLoader createProjectClassLoader() throws IOException {
+        URL[] runtimeUrls = new URL[compilePath.size()];
+        for (int i = 0; i < compilePath.size(); i++) {
+            Path element = compilePath.get(i);
+            runtimeUrls[i] = element.toFile().toURI().toURL();
+        }
+        return new URLClassLoader(runtimeUrls, Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/GeneratorMojoTask.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/GeneratorMojoTask.java
@@ -1,0 +1,49 @@
+package gg.jte.gradle;
+
+import gg.jte.TemplateEngine;
+import gg.jte.resolve.DirectoryCodeResolver;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.SourceTask;
+import org.gradle.api.tasks.TaskAction;
+
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+public class GeneratorMojoTask extends JteTaskBase {
+
+    public GeneratorMojoTask() {
+        super();
+        targetDirectory = Paths.get(getProject().getBuildDir().getAbsolutePath(), "generated-sources", "jte");
+    }
+
+    @TaskAction
+    public void execute() {
+        Logger logger = getLogger();
+        long start = System.nanoTime();
+
+        logger.info("Generating jte templates found in " + sourceDirectory);
+
+        TemplateEngine templateEngine = TemplateEngine.create(new DirectoryCodeResolver(sourceDirectory), targetDirectory, contentType);
+        templateEngine.setTrimControlStructures(trimControlStructures);
+        templateEngine.setHtmlTags(htmlTags);
+        templateEngine.setHtmlAttributes(htmlAttributes);
+        templateEngine.setHtmlCommentsPreserved(htmlCommentsPreserved);
+
+        int amount;
+        try {
+            templateEngine.cleanAll();
+            amount = templateEngine.generateAll().size();
+        } catch (Exception e) {
+            logger.error("Failed to generate templates.", e);
+
+            throw e;
+        }
+
+        long end = System.nanoTime();
+        long duration = TimeUnit.NANOSECONDS.toSeconds(end - start);
+        logger.info("Successfully generated " + amount + " jte file" + (amount == 1 ? "" : "s") + " in " + duration + "s to " + targetDirectory);
+
+        getProject().getTasks().withType(SourceTask.class).all(sourceTask -> sourceTask.include(targetDirectory.toAbsolutePath().toString()));
+    }
+
+}

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteGradle.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteGradle.java
@@ -1,0 +1,12 @@
+package gg.jte.gradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class JteGradle implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getTasks().register("generatorMojo", GeneratorMojoTask.class);
+        project.getTasks().register("compilerMojo", CompilerMojoTask.class);
+    }
+}

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteParameters.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteParameters.java
@@ -1,0 +1,29 @@
+package gg.jte.gradle;
+
+import gg.jte.ContentType;
+
+import java.nio.file.Path;
+
+public interface JteParameters {
+
+    Path getSourceDirectory();
+    void setSourceDirectory(Path value) ;
+
+    Path getTargetDirectory();
+    void setTargetDirectory(Path value);
+
+    ContentType getContentType();
+    void setContentType(ContentType value);
+
+    boolean getTrimControlStructures();
+    void setTrimControlStructures(boolean value);
+
+    String[] getHtmlTags();
+    void setHtmlTags(String[] value);
+
+    String[] getHtmlAttributes();
+    void setHtmlAttributes(String[] value);
+
+    boolean getHtmlCommentPreserved();
+    void setHtmlCommentPreserved(boolean value);
+}

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteTaskBase.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteTaskBase.java
@@ -1,0 +1,87 @@
+package gg.jte.gradle;
+
+import gg.jte.ContentType;
+import org.gradle.api.DefaultTask;
+
+import java.nio.file.Path;
+
+public class JteTaskBase extends DefaultTask implements JteParameters {
+
+    protected Path sourceDirectory;
+    protected Path targetDirectory;
+    protected ContentType contentType;
+    protected boolean trimControlStructures;
+    protected String[] htmlTags;
+    protected String[] htmlAttributes;
+    protected boolean htmlCommentsPreserved;
+
+    @Override
+    public Path getSourceDirectory() {
+        return sourceDirectory;
+    }
+
+    @Override
+    public void setSourceDirectory(Path value) {
+        sourceDirectory = value;
+    }
+
+    @Override
+    public Path getTargetDirectory() {
+        return targetDirectory;
+    }
+
+    @Override
+    public void setTargetDirectory(Path value) {
+        targetDirectory = value;
+    }
+
+    @Override
+    public ContentType getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public void setContentType(ContentType value) {
+        contentType = value;
+    }
+
+    @Override
+    public boolean getTrimControlStructures() {
+        return trimControlStructures;
+    }
+
+    @Override
+    public void setTrimControlStructures(boolean value) {
+        trimControlStructures = value;
+    }
+
+    @Override
+    public String[] getHtmlTags() {
+        return htmlTags;
+    }
+
+    @Override
+    public void setHtmlTags(String[] value) {
+        htmlTags = value;
+    }
+
+    @Override
+    public String[] getHtmlAttributes() {
+        return htmlAttributes;
+    }
+
+    @Override
+    public void setHtmlAttributes(String[] value) {
+        htmlAttributes = value;
+    }
+
+    @Override
+    public boolean getHtmlCommentPreserved() {
+        return htmlCommentsPreserved;
+    }
+
+    @Override
+    public void setHtmlCommentPreserved(boolean value) {
+        htmlCommentsPreserved = value;
+    }
+}

--- a/jte-gradle-plugin/src/main/resources/META-INF/gradle-plugins/gg.jte.gradle.properties
+++ b/jte-gradle-plugin/src/main/resources/META-INF/gradle-plugins/gg.jte.gradle.properties
@@ -1,0 +1,1 @@
+implementation-class=gg.jte.gradle.JteGradle

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,11 @@
         <module>jte-runtime</module>
         <module>jte</module>
         <module>jte-maven-plugin</module>
+        <module>jte-gradle-plugin</module>
         <module>jte-runtime-test</module>
         <module>jte-runtime-cp-test</module>
         <module>jte-test-report</module>
         <module>jte-deploy-nexus</module>
-        <module>jte-gradle-plugin</module>
     </modules>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>jte-runtime-cp-test</module>
         <module>jte-test-report</module>
         <module>jte-deploy-nexus</module>
+        <module>jte-gradle-plugin</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
This PR adds a gradle plugin with two tasks, `CompilerMojo` & `GeneratorMojo`. I'm not a pro at gradle, so something might be of low quality.

Related issue #16.

<details>
<summary>To use the tasks locally</summary>

Put that into `settings.gradle.build`:
```kts
pluginManagement {
    buildscript {
        repositories {
            flatDir {
                dir("PATH TO A FOLDER WITH A BUILT PLUGIN")
            }
        }

        dependencies {
            classpath("gg.jte:jte-gradle-plugin:1.6.1-SNAPSHOT") // Remember to keep the version updated
        }
    }
}
```

And from `build.gradle.kts` you can use the tasks:
```kts
import java.nio.file.Path
import gg.jte.ContentType

plugins {
    id("gg.jte.gradle")
}

val jtePath = Path.of(project.projectDir.absolutePath,"src", "jte")

tasks.generatorMojo {
    sourceDirectory = jtePath
    contentType = ContentType.Html
}

tasks.compilerMojo {
    sourceDirectory = jtePath
    targetDirectory = Path.of(project.projectDir.absolutePath, "artifacts", "jte-compiled")
    contentType = ContentType.Html
}

tasks.build {
    dependsOn(tasks.compilerMojo)
}
```

</details>