### PR TITLE
Gradle path fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,10 @@ Temporary Items
 /jte-runtime-test-kotlin/jte-classes/
 /jte-runtime-test-gradle/jte-classes/
 /jte-hotreload-test/jte-classes/
+
+### VS Code / VS Code Java extension (uses Eclipse code) ###
+.project
+.settings/
+.classpath
+bin/
+.factorypath

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -645,7 +645,7 @@ tasks.generateJte {
     contentType = ContentType.Html
 }
 
-sourceSets.main.java.srcDirs += tasks.generateJte.targetDirectory
+sourceSets.main.java.srcDir(tasks.generateJte.targetDirectory)
 
 tasks.compileJava {
     dependsOn(tasks.generateJte)
@@ -677,7 +677,7 @@ tasks.generateJte {
 
 sourceSets {
     main {
-        java.srcDirs(tasks.generateJte.get().targetDirectory)
+        java.srcDir(tasks.generateJte.get().targetDirectory)
     }
 }
 

--- a/jte-runtime-cp-test-gradle-kotlin/build.gradle.kts
+++ b/jte-runtime-cp-test-gradle-kotlin/build.gradle.kts
@@ -28,7 +28,7 @@ tasks.generateJte {
 
 sourceSets {
     main {
-        java.srcDirs(tasks.generateJte.get().targetDirectory)
+        java.srcDir(tasks.generateJte.get().targetDirectory)
     }
 }
 

--- a/jte-runtime-cp-test-gradle/build.gradle
+++ b/jte-runtime-cp-test-gradle/build.gradle
@@ -27,7 +27,7 @@ tasks.generateJte {
     contentType = ContentType.Html
 }
 
-sourceSets.main.java.srcDirs += tasks.generateJte.targetDirectory
+sourceSets.main.java.srcDir(tasks.generateJte.targetDirectory)
 
 tasks.compileJava {
     dependsOn(tasks.generateJte)

--- a/script/build-local.sh
+++ b/script/build-local.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Run the builds and tests, but only using the local OS and Java versions.
-# This is not a substitute for the full Git workflow tests, but makes
+# This is not a substitute for the full Git workflow tests, but makes it easier
+# to do testing before commit.
 
 if [[ -z "$PROJECT_PATH" ]]; then
     PROJECT_PATH=$(git rev-parse --show-toplevel)

--- a/script/build-local.sh
+++ b/script/build-local.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Run the builds and tests, but only using the local OS and Java versions.
+# This is not a substitute for the full Git workflow tests, but makes
+
+if [[ -z "$PROJECT_PATH" ]]; then
+    PROJECT_PATH=$(git rev-parse --show-toplevel)
+fi
+
+(cd $PROJECT_PATH &&
+MAVEN_OPTS='-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn' ./mvnw install --file pom.xml --batch-mode)
+
+(cd $PROJECT_PATH/jte-gradle-plugin && ./gradlew publishToMavenLocal)
+(cd $PROJECT_PATH/jte-runtime-test-gradle && ./gradlew test)
+(cd $PROJECT_PATH/jte-runtime-cp-test-gradle && ./gradlew test)
+(cd $PROJECT_PATH/jte-runtime-cp-test-gradle-kotlin && ./gradlew test)


### PR DESCRIPTION
I came across a build issue when trying to run the gradle tests in a dev environment. It doesn't seem to happen in the clean environment of the github workflow.

The fix is a minor change to build.gradle files.
I've added the shell script I was using to run all the tests locally.

Side note: https://github.com/nektos/act is an alternative way to run tests locally, with its own limitations.