### PR TITLE
Run tests against java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [1.8, 11, 16]
+        java_version: [1.8, 11, 17]
         os: [windows-latest, macOS-latest, ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Building with JDK 17 looks good so far. Maven build passes, so no adjustments to jte required 👍 Users out there should be able to use the latest jte version + JDK 17 with no problem.

However, Gradle is not yet ready for JDK 17:
https://github.com/gradle/gradle/issues/16857

This can be merged as soon as Gradle 7.3 is released with official support for 17.