### PR TITLE
Unsafe can only be used for rendering strings

### DIFF
--- a/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngine_HtmlOutputEscapingTest.java
+++ b/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngine_HtmlOutputEscapingTest.java
@@ -1155,7 +1155,7 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "p1", "<script>evil()</script>", "p2", "p2", "p3", "p3"), output);
 
-        assertThat(output.toString()).isEqualTo("<span data-title=\"This is a key with &#34;quotes&#34; and params &lt;i>&#34;&lt;script>evil()&lt;/script>&#34;&lt;/i>, &lt;b>&#34;p2&#34;&lt;/b>, &#34;p3&#34;...\"></span>");
+        assertThat(output.toString()).isEqualTo("<span data-title=\"This is a key with &#34;quotes&#34; and params &lt;i>&#34;&amp;lt;script&amp;gt;evil()&amp;lt;/script&amp;gt;&#34;&lt;/i>, &lt;b>&#34;p2&#34;&lt;/b>, &#34;p3&#34;...\"></span>");
     }
 
     @Test

--- a/jte-runtime/src/main/java/gg/jte/html/OwaspHtmlTemplateOutput.java
+++ b/jte-runtime/src/main/java/gg/jte/html/OwaspHtmlTemplateOutput.java
@@ -41,10 +41,8 @@ public class OwaspHtmlTemplateOutput implements HtmlTemplateOutput {
         if (value != null) {
             if (tagName != null && attributeName != null) {
                 writeTagAttributeUserContent(value);
-            } else if (tagName != null) {
-                writeTagBodyUserContent(value);
             } else {
-                writeContent(value);
+                writeTagBodyUserContent(value);
             }
         }
     }

--- a/jte/src/main/java/gg/jte/compiler/java/JavaCodeGenerator.java
+++ b/jte/src/main/java/gg/jte/compiler/java/JavaCodeGenerator.java
@@ -315,12 +315,10 @@ public class JavaCodeGenerator implements CodeGenerator {
 
     @Override
     public void onUnsafeCodePart(int depth, String codePart) {
-        if (config.contentType == ContentType.Html) {
-            writeIndentation(depth);
-            javaCode.append("jteOutput.setContext(null, null);\n");
-        }
-
-        writeCodePart(depth, codePart);
+        writeIndentation(depth);
+        javaCode.append("jteOutput.writeContent(");
+        javaCode.append(codePart);
+        javaCode.append(");\n");
     }
 
     private void writeCodePart(int depth, String codePart) {

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -277,7 +277,7 @@ public class TemplateEngineTest {
     @Test
     void unsafeInContentBlock() {
         model.array = new int[]{1, 2, 3};
-        givenTemplate("${@`$unsafe{model.array.length}`}");
+        givenTemplate("${@`$unsafe{\"\" + model.array.length}`}");
         thenOutputIs("3");
     }
 

--- a/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
@@ -1217,11 +1217,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
     @Test
     void localization_noParams() {
         codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span alt=\"${localizer.localize(\"no-params\")}\">${localizer.localize(\"no-params\")}</span> $unsafe{localizer.localize(\"no-params\")}");
+                "<span alt=\"${localizer.localize(\"no-params\")}\">${localizer.localize(\"no-params\")}</span>");
 
         templateEngine.render("template.jte", localizer, output);
 
-        assertThat(output.toString()).isEqualTo("<span alt=\"This is a key without params\">This is a key without params</span> This is a key without params");
+        assertThat(output.toString()).isEqualTo("<span alt=\"This is a key without params\">This is a key without params</span>");
     }
 
     @Test
@@ -1287,7 +1287,7 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
         templateEngine.render("template.jte", TemplateUtils.toMap("localizer", localizer, "p1", "<script>evil()</script>", "p2", "p2", "p3", "p3"), output);
 
-        assertThat(output.toString()).isEqualTo("<span data-title=\"This is a key with &#34;quotes&#34; and params &lt;i>&#34;&lt;script>evil()&lt;/script>&#34;&lt;/i>, &lt;b>&#34;p2&#34;&lt;/b>, &#34;p3&#34;...\"></span>");
+        assertThat(output.toString()).isEqualTo("<span data-title=\"This is a key with &#34;quotes&#34; and params &lt;i>&#34;&amp;lt;script&amp;gt;evil()&amp;lt;/script&amp;gt;&#34;&lt;/i>, &lt;b>&#34;p2&#34;&lt;/b>, &#34;p3&#34;...\"></span>");
     }
 
     @Test
@@ -1366,24 +1366,14 @@ public class TemplateEngine_HtmlOutputEscapingTest {
     }
 
     @Test
-    void localization_primitives_unsafe() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>$unsafe{localizer.localize(\"all-primitives\", false, (byte)1, (short)2, 3, 4L, 5.0f, 6.0, 'c')}</span>");
-
-        templateEngine.render("template.jte", localizer, output);
-
-        assertThat(output.toString()).isEqualTo("<span>boolean: false, byte: 1, short: 2, int: 3, long: 4, float: 5.0, double: 6.0, char: c</span>");
-    }
-
-    @Test
     void localization_enum() {
         codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
                 "@param gg.jte.ContentType contentType\n" +
-                "<span alt=\"${localizer.localize(\"enum\", contentType)}\">${localizer.localize(\"enum\", contentType)}</span> Unsafe: $unsafe{localizer.localize(\"enum\", contentType)}");
+                "<span alt=\"${localizer.localize(\"enum\", contentType)}\">${localizer.localize(\"enum\", contentType)}</span>");
 
         templateEngine.render("template.jte", TemplateUtils.toMap("localizer", localizer, "contentType", ContentType.Html), output);
 
-        assertThat(output.toString()).isEqualTo("<span alt=\"Content type is: Html\">Content type is: Html</span> Unsafe: Content type is: Html");
+        assertThat(output.toString()).isEqualTo("<span alt=\"Content type is: Html\">Content type is: Html</span>");
     }
 
     @Test

--- a/jte/src/test/java/gg/jte/TemplateEngine_TrimControlStructuresTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngine_TrimControlStructuresTest.java
@@ -346,12 +346,12 @@ public class TemplateEngine_TrimControlStructuresTest {
     @Test
     void variable_unsafe() {
         givenTemplate(
-                "!{int x = 1;}\n" +
-                "!{int y = 2;}\n" +
+                "!{String x = \"1\";}\n" +
+                "!{String y = \"2\";}\n" +
                 "$unsafe{x + y}\n" +
                 "done..\n"
         );
-        thenOutputIs("3\ndone..\n");
+        thenOutputIs("12\ndone..\n");
     }
 
     @Test


### PR DESCRIPTION
Currently `$unsafe{}` can be used for all types where `${}` is supported.

For primitive types this doesn't make sense. For $`gg.jte.Content` this is more confusing than useful.

This PR limits `$unsafe{}` to `java.lang.String` only.

Internally, the compiler now generates a `writeContent()` for unsafe output.