### PR TITLE
Add the ability to override the jte template suffix (so .kte templates are supported in spring boot)

### DIFF
--- a/jte-spring-boot-starter/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
+++ b/jte-spring-boot-starter/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
@@ -31,7 +31,7 @@ public class JteAutoConfiguration {
     @ConditionalOnMissingBean(JteViewResolver.class)
     public JteViewResolver jteViewResolver(TemplateEngine templateEngine) {
 
-        return new JteViewResolver(templateEngine);
+        return new JteViewResolver(templateEngine, jteProperties.getTemplateSuffix());
     }
 
 

--- a/jte-spring-boot-starter/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
+++ b/jte-spring-boot-starter/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
@@ -11,6 +11,15 @@ public class JteProperties {
 
     private String productionProfileName = "prod";
     private String templateLocation = "src/main/jte";
+    private String templateSuffix = ".jte";
+
+    public String getTemplateSuffix() {
+        return templateSuffix;
+    }
+
+    public void setTemplateSuffix(final String templateSuffix) {
+        this.templateSuffix = templateSuffix;
+    }
 
     public String getProductionProfileName() {
         return productionProfileName;

--- a/jte-spring-boot-starter/src/main/java/gg/jte/springframework/boot/autoconfigure/JteViewResolver.java
+++ b/jte-spring-boot-starter/src/main/java/gg/jte/springframework/boot/autoconfigure/JteViewResolver.java
@@ -11,9 +11,9 @@ public class JteViewResolver  extends AbstractTemplateViewResolver {
 
     private final TemplateEngine templateEngine;
 
-    public JteViewResolver(TemplateEngine templateEngine) {
+    public JteViewResolver(TemplateEngine templateEngine, final String templateSuffix) {
         this.templateEngine = templateEngine;
-        this.setSuffix(".jte");
+        this.setSuffix(templateSuffix);
         this.setViewClass(JteView.class);
         this.setContentType(MediaType.TEXT_HTML_VALUE);
         this.setOrder(Ordered.HIGHEST_PRECEDENCE);


### PR DESCRIPTION
It was only possible to compile jte templates in the spring boot starter, this PR makes sure that you can override that default to also allow for kte templates