### PR TITLE
Implement ResourceCodeResolver.getLastModified

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -439,7 +439,7 @@ Sometimes it is required to output text as is. The `@raw` keyword can be used to
 
 ### For a regular website
 
-When using the `DirectoryCodeResolver`, hot reloading is supported out of the box. Before a template is resolved, the modification timestamp of the template file and all of its dependencies is checked. If there is any modification detected, the template is recompiled and the old one discarded to GC.
+When using the `DirectoryCodeResolver` (or the `ResourceCodeResolver` with resources located outside of JAR files), hot reloading is supported out of the box. Before a template is resolved, the modification timestamp of the template file and all of its dependencies is checked. If there is any modification detected, the template is recompiled and the old one discarded to GC.
 
 > It makes sense to do this on your local development environment only. When running in production, for maximum performance and security [precompiled templates](#precompiling-templates) are recommended instead.
 
@@ -654,7 +654,7 @@ There is a [Maven plugin](https://github.com/casid/jte-maven-compiler-plugin) yo
 
 #### Gradle
 
-Since 1.6.0 there is a <a href="https://plugins.gradle.org/plugin/gg.jte.gradle">Gradle plugin</a> you can use to generate all templates during the Gradle build. Please note that paths specified in Java need to match those specified in Gradle. 
+Since 1.6.0 there is a <a href="https://plugins.gradle.org/plugin/gg.jte.gradle">Gradle plugin</a> you can use to generate all templates during the Gradle build. Please note that paths specified in Java need to match those specified in Gradle.
 
 > Make sure that the jte gradle plugin version always matches the jte dependency version.
 
@@ -756,15 +756,15 @@ Let's implement `gg.jte.support.LocalizationSupport`. There's only one method to
 
 ```java
 public static class JteLocalizer implements gg.jte.support.LocalizationSupport {
-    
+
     private final OtherFrameworkLocalizer frameworkLocalizer;
     private final Locale locale;
-    
+
     public JteLocalizer(OtherFrameworkLocalizer frameworkLocalizer, Locale locale) {
         this.frameworkLocalizer = frameworkLocalizer;
         this.locale = locale;
     }
-    
+
     @Override
     public String lookup(String key) {
         // However this works in your localization framework
@@ -793,15 +793,15 @@ public class JteContext {
     public static Content localize(String key) {
         context.get().localize(key);
     }
-    
+
     public static Content localize(String key, Object... params) {
         context.get().localize(key, params);
     }
-    
+
     static void init(JteLocalizer localizer) {
         context.set(localizer);
     }
-    
+
     static void dispose() {
         context.remove();
     }

--- a/jte/src/main/java/gg/jte/resolve/ResourceCodeResolver.java
+++ b/jte/src/main/java/gg/jte/resolve/ResourceCodeResolver.java
@@ -3,9 +3,12 @@ package gg.jte.resolve;
 import gg.jte.CodeResolver;
 import gg.jte.compiler.IoUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 
 /**
  * Resolves template code within a given resources root.
@@ -46,7 +49,17 @@ public class ResourceCodeResolver implements CodeResolver {
 
     @Override
     public long getLastModified(String name) {
-        return 0;
+        URL res = getClassLoader().getResource(root + name);
+        if (res == null) {
+            return 0;
+        }
+
+        try {
+            // Returns 0 if the file does not exist or an I/O error occurs.
+            return new File(res.toURI()).lastModified();
+        } catch (IllegalArgumentException | URISyntaxException e) {
+            return 0;
+        }
     }
 
     private ClassLoader getClassLoader() {

--- a/jte/src/test/java/gg/jte/resolve/ResourceCodeResolverTest.java
+++ b/jte/src/test/java/gg/jte/resolve/ResourceCodeResolverTest.java
@@ -36,12 +36,12 @@ public class ResourceCodeResolverTest {
     }
 
     @Test
-    void lastModifiedNotSupported() {
+    void lastModified() {
         resourceCodeResolver = new ResourceCodeResolver("benchmark");
 
         long lastModified = resourceCodeResolver.getLastModified("welcome.jte");
 
-        assertThat(lastModified).isEqualTo(0L);
+        assertThat(lastModified).isNotEqualTo(0L);
     }
 
     @Test


### PR DESCRIPTION
Hot reloading is currently unsupport for `ResourceCodeResolver` due to `getLastModified` always returning `0`. By implementing the method on a best-effort basis, hot reloading can be supported when the resource URL points to a regular file outside a JAR file which is usually the case during development time. A project which uses jte can then be rebuilt which will cause the changes to be reflected.