### PR TITLE
Replace owasp java encoder with faster implementation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -356,7 +356,7 @@ In `Html` mode, user content `${}` is automatically escaped, depending what part
 
 ### HTML tag bodies
 
-User output in HTML tag bodies is escaped with `org.owasp.encoder.Encode#forHtmlContent` (`org.owasp.encoder.Encode#forHtml` before jte 1.5.0).
+User output in HTML tag bodies is escaped with `gg.jte.html.escape.Escape.htmlContent`.
 
 ```htm
 <div>${userName}</div>
@@ -368,7 +368,7 @@ the output would be `<div>&lt;script&gt;alert('xss');&lt;/script&gt;</div>`.
 
 ### HTML attributes
 
-User output in HTML attributes is escaped with `org.owasp.encoder.Encode#forHtmlAttribute`. It ensures that all quotes are escaped, so that an attacker cannot escape the attribute.
+User output in HTML attributes is escaped with `gg.jte.html.escape.Escape.htmlAttribute`. It ensures that all quotes are escaped, so that an attacker cannot escape the attribute.
 
 ```htm
 <div data-title="Hello ${userName}"></div>
@@ -380,7 +380,7 @@ the output would be `<div data-title="Hello &#34;>&lt;script>alert(&#39;xss&#39;
 
 ### JavaScript attributes
 
-User output in HTML attributes is escaped with `org.owasp.encoder.Encode#forJavaScriptAttribute`. Those are all HTML attributes starting with `on`.
+User output in HTML attributes is escaped with `gg.jte.html.escape.Escape.javaScriptAttribute`. Those are all HTML attributes starting with `on`.
 
 ```htm
 <span onclick="showName('${userName}')">Click me</span>

--- a/jte-runtime/pom.xml
+++ b/jte-runtime/pom.xml
@@ -18,14 +18,6 @@
         <version>2.3.3-SNAPSHOT</version>
     </parent>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.owasp.encoder</groupId>
-            <artifactId>encoder</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-    </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/jte-runtime/src/main/java/gg/jte/TemplateOutput.java
+++ b/jte-runtime/src/main/java/gg/jte/TemplateOutput.java
@@ -1,13 +1,13 @@
 package gg.jte;
 
-import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
 @SuppressWarnings("unused") // Methods are called by generated templates
 public interface TemplateOutput {
-    Writer getWriter();
 
     void writeContent(String value);
+
+    void writeContent(String value, int beginIndex, int endIndex);
 
     default void writeBinaryContent(byte[] value) {
         writeContent(new String(value, StandardCharsets.UTF_8));

--- a/jte-runtime/src/main/java/gg/jte/html/OwaspHtmlTemplateOutput.java
+++ b/jte-runtime/src/main/java/gg/jte/html/OwaspHtmlTemplateOutput.java
@@ -2,13 +2,9 @@ package gg.jte.html;
 
 import gg.jte.Content;
 import gg.jte.TemplateOutput;
+import gg.jte.html.escape.Escape;
 import gg.jte.runtime.StringUtils;
 import gg.jte.output.StringOutput;
-import org.owasp.encoder.Encode;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.io.Writer;
 
 /**
  * See <a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">OWASP Cross Site Prevention Cheat Sheet</a>
@@ -59,14 +55,10 @@ public class OwaspHtmlTemplateOutput implements HtmlTemplateOutput {
     }
 
     private void writeTagBodyUserContent(String value) {
-        try {
-            if ("script".equals(tagName)) {
-                Encode.forJavaScriptBlock(getWriter(), value);
-            } else {
-                Encode.forHtmlContent(getWriter(), value);
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        if ("script".equals(tagName)) {
+            Escape.javaScriptBlock(value, templateOutput);
+        } else {
+            Escape.htmlContent(value, templateOutput);
         }
     }
 
@@ -75,25 +67,21 @@ public class OwaspHtmlTemplateOutput implements HtmlTemplateOutput {
             return;
         }
 
-        try {
-            if (attributeName.startsWith("on")) {
-                Encode.forJavaScriptAttribute(getWriter(), value);
-            } else {
-                Encode.forHtmlAttribute(getWriter(), value);
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        if (attributeName.startsWith("on")) {
+            Escape.javaScriptAttribute(value, templateOutput);
+        } else {
+            Escape.htmlAttribute(value, templateOutput);
         }
-    }
-
-    @Override
-    public Writer getWriter() {
-        return templateOutput.getWriter();
     }
 
     @Override
     public void writeContent(String value) {
         templateOutput.writeContent(value);
+    }
+
+    @Override
+    public void writeContent(String value, int beginIndex, int endIndex) {
+        templateOutput.writeContent(value, beginIndex, endIndex);
     }
 
     @Override

--- a/jte-runtime/src/main/java/gg/jte/html/escape/Escape.java
+++ b/jte-runtime/src/main/java/gg/jte/html/escape/Escape.java
@@ -24,9 +24,7 @@ public class Escape {
             }
         }
 
-        if (lastIndex < length) {
-            output.writeContent(value, lastIndex, length);
-        }
+        flushRemaining(value, output, lastIndex, length);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -52,9 +50,7 @@ public class Escape {
             }
         }
 
-        if (lastIndex < length) {
-            output.writeContent(value, lastIndex, length);
-        }
+        flushRemaining(value, output, lastIndex, length);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -98,9 +94,7 @@ public class Escape {
             }
         }
 
-        if (lastIndex < length) {
-            output.writeContent(value, lastIndex, length);
-        }
+        flushRemaining(value, output, lastIndex, length);
     }
 
     @SuppressWarnings("DuplicatedCode")
@@ -138,14 +132,20 @@ public class Escape {
             }
         }
 
-        if (lastIndex < length) {
-            output.writeContent(value, lastIndex, length);
-        }
+        flushRemaining(value, output, lastIndex, length);
     }
 
     private static int flushAndEscape(String value, int lastIndex, int currentIndex, String escapeSequence, TemplateOutput output) {
         output.writeContent(value, lastIndex, currentIndex);
         output.writeContent(escapeSequence);
         return currentIndex + 1;
+    }
+
+    private static void flushRemaining(String value, TemplateOutput output, int lastIndex, int length) {
+        if (lastIndex == 0) {
+            output.writeContent(value);
+        } else if (lastIndex < length) {
+            output.writeContent(value, lastIndex, length);
+        }
     }
 }

--- a/jte-runtime/src/main/java/gg/jte/html/escape/Escape.java
+++ b/jte-runtime/src/main/java/gg/jte/html/escape/Escape.java
@@ -1,0 +1,151 @@
+package gg.jte.html.escape;
+
+import gg.jte.TemplateOutput;
+
+public class Escape {
+
+    @SuppressWarnings("DuplicatedCode")
+    public static void htmlContent(String value, TemplateOutput output) {
+        int lastIndex = 0;
+        int length = value.length();
+
+        for (int i = 0; i < length; i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '&':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "&amp;", output);
+                    break;
+                case '<':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "&lt;", output);
+                    break;
+                case '>':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "&gt;", output);
+                    break;
+            }
+        }
+
+        if (lastIndex < length) {
+            output.writeContent(value, lastIndex, length);
+        }
+    }
+
+    @SuppressWarnings("DuplicatedCode")
+    public static void htmlAttribute(String value, TemplateOutput output) {
+        int lastIndex = 0;
+        int length = value.length();
+
+        for (int i = 0; i < length; i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\'':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "&#39;", output);
+                    break;
+                case '"':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "&#34;", output);
+                    break;
+                case '&':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "&amp;", output);
+                    break;
+                case '<':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "&lt;", output);
+                    break;
+            }
+        }
+
+        if (lastIndex < length) {
+            output.writeContent(value, lastIndex, length);
+        }
+    }
+
+    @SuppressWarnings("DuplicatedCode")
+    public static void javaScriptBlock(String value, TemplateOutput output) {
+        int lastIndex = 0;
+        int length = value.length();
+
+        for (int i = 0; i < length; i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\'':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\'", output);
+                    break;
+                case '"':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\\"", output);
+                    break;
+                case '/':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\/", output);
+                    break;
+                case '-':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\-", output);
+                    break;
+                case '\\':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\\\", output);
+                    break;
+                case '\n':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\n", output);
+                    break;
+                case '\t':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\t", output);
+                    break;
+                case '\r':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\r", output);
+                    break;
+                case '\f':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\f", output);
+                    break;
+                case '\b':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\b", output);
+                    break;
+            }
+        }
+
+        if (lastIndex < length) {
+            output.writeContent(value, lastIndex, length);
+        }
+    }
+
+    @SuppressWarnings("DuplicatedCode")
+    public static void javaScriptAttribute(String value, TemplateOutput output) {
+        int lastIndex = 0;
+        int length = value.length();
+
+        for (int i = 0; i < length; i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\'':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\x27", output);
+                    break;
+                case '"':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\x22", output);
+                    break;
+                case '\\':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\\\", output);
+                    break;
+                case '\n':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\n", output);
+                    break;
+                case '\t':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\t", output);
+                    break;
+                case '\r':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\r", output);
+                    break;
+                case '\f':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\f", output);
+                    break;
+                case '\b':
+                    lastIndex = flushAndEscape(value, lastIndex, i, "\\b", output);
+                    break;
+            }
+        }
+
+        if (lastIndex < length) {
+            output.writeContent(value, lastIndex, length);
+        }
+    }
+
+    private static int flushAndEscape(String value, int lastIndex, int currentIndex, String escapeSequence, TemplateOutput output) {
+        output.writeContent(value, lastIndex, currentIndex);
+        output.writeContent(escapeSequence);
+        return currentIndex + 1;
+    }
+}

--- a/jte-runtime/src/main/java/gg/jte/output/FileOutput.java
+++ b/jte-runtime/src/main/java/gg/jte/output/FileOutput.java
@@ -23,14 +23,18 @@ public class FileOutput implements TemplateOutput, Closeable {
     }
 
     @Override
-    public Writer getWriter() {
-        return writer;
-    }
-
-    @Override
     public void writeContent(String value) {
         try {
             writer.write(value);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void writeContent(String value, int beginIndex, int endIndex) {
+        try {
+            writer.write(value, beginIndex, endIndex - beginIndex);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/jte-runtime/src/main/java/gg/jte/output/PrintWriterOutput.java
+++ b/jte-runtime/src/main/java/gg/jte/output/PrintWriterOutput.java
@@ -3,7 +3,6 @@ package gg.jte.output;
 import gg.jte.TemplateOutput;
 
 import java.io.PrintWriter;
-import java.io.Writer;
 
 public class PrintWriterOutput implements TemplateOutput {
     private final PrintWriter writer;
@@ -13,12 +12,12 @@ public class PrintWriterOutput implements TemplateOutput {
     }
 
     @Override
-    public Writer getWriter() {
-        return writer;
+    public void writeContent(String value) {
+        writer.write(value);
     }
 
     @Override
-    public void writeContent(String value) {
-        writer.write(value);
+    public void writeContent(String value, int beginIndex, int endIndex) {
+        writer.write(value, beginIndex, endIndex - beginIndex);
     }
 }

--- a/jte-runtime/src/main/java/gg/jte/output/StringOutput.java
+++ b/jte-runtime/src/main/java/gg/jte/output/StringOutput.java
@@ -16,13 +16,13 @@ public class StringOutput extends Writer implements TemplateOutput {
     }
 
     @Override
-    public Writer getWriter() {
-        return this;
+    public void writeContent(String value) {
+        stringBuilder.append(value);
     }
 
     @Override
-    public void writeContent(String value) {
-        stringBuilder.append(value);
+    public void writeContent(String value, int beginIndex, int endIndex) {
+        stringBuilder.append(value, beginIndex, endIndex);
     }
 
     @Override

--- a/jte-runtime/src/main/java/gg/jte/output/Utf8ByteArrayOutput.java
+++ b/jte-runtime/src/main/java/gg/jte/output/Utf8ByteArrayOutput.java
@@ -2,8 +2,6 @@ package gg.jte.output;
 
 import gg.jte.TemplateOutput;
 
-import java.io.IOException;
-import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -14,7 +12,7 @@ import java.util.Arrays;
  *
  * CAUTION: You must enable {@link gg.jte.TemplateEngine#setBinaryStaticContent(boolean)}, otherwise this class won't provide any benefits over {@link StringOutput}!
  */
-public final class Utf8ByteArrayOutput extends Writer implements TemplateOutput {
+public final class Utf8ByteArrayOutput implements TemplateOutput {
 
     private byte[] buffer;
     private int position;
@@ -28,13 +26,13 @@ public final class Utf8ByteArrayOutput extends Writer implements TemplateOutput 
     }
 
     @Override
-    public Writer getWriter() {
-        return this;
+    public void writeContent(String value) {
+        writeBinaryContent(value.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
-    public void writeContent(String value) {
-        writeBinaryContent(value.getBytes(StandardCharsets.UTF_8));
+    public void writeContent(String value, int beginIndex, int endIndex) {
+        writeBinaryContent(value.substring(beginIndex, endIndex).getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
@@ -42,26 +40,6 @@ public final class Utf8ByteArrayOutput extends Writer implements TemplateOutput 
         ensureCapacity(position + value.length);
         System.arraycopy(value, 0, buffer, position, value.length);
         position += value.length;
-    }
-
-    @Override
-    public void write(String value) {
-        writeBinaryContent(value.getBytes(StandardCharsets.UTF_8));
-    }
-
-    @Override
-    public void write(char[] cbuf, int off, int len) throws IOException {
-        writeContent(new String(cbuf, off, len));
-    }
-
-    @Override
-    public void flush() {
-        // nothing to do
-    }
-
-    @Override
-    public void close() {
-        // nothing to do
     }
 
     public byte[] toByteArray() {

--- a/jte-runtime/src/main/java/gg/jte/output/WriterOutput.java
+++ b/jte-runtime/src/main/java/gg/jte/output/WriterOutput.java
@@ -14,14 +14,18 @@ public class WriterOutput implements TemplateOutput {
     }
 
     @Override
-    public Writer getWriter() {
-        return writer;
-    }
-
-    @Override
     public void writeContent(String value) {
         try {
             writer.write(value);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void writeContent(String value, int beginIndex, int endIndex) {
+        try {
+            writer.write(value, beginIndex, endIndex - beginIndex);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
@@ -9,7 +9,6 @@ import gg.jte.runtime.TemplateUtils;
 import gg.jte.support.LocalizationSupport;
 import org.junit.jupiter.api.Test;
 
-import java.io.Writer;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -1103,13 +1102,13 @@ public class TemplateEngine_HtmlOutputEscapingTest {
             final StringBuilder history = new StringBuilder();
 
             @Override
-            public Writer getWriter() {
-                return output.getWriter();
+            public void writeContent(String value) {
+                output.writeContent(value);
             }
 
             @Override
-            public void writeContent(String value) {
-                output.writeContent(value);
+            public void writeContent(String value, int beginIndex, int endIndex) {
+                output.writeContent(value, beginIndex, endIndex);
             }
 
             @Override

--- a/jte/src/test/java/gg/jte/html/escape/Escape_HtmlAttributeTest.java
+++ b/jte/src/test/java/gg/jte/html/escape/Escape_HtmlAttributeTest.java
@@ -1,0 +1,45 @@
+package gg.jte.html.escape;
+
+import gg.jte.output.StringOutput;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Escape_HtmlAttributeTest {
+
+    @Test
+    void empty() {
+        assertThat(escape("")).isEqualTo("");
+    }
+
+    @Test
+    void nothingToEscape() {
+        assertThat(escape("script")).isEqualTo("script");
+    }
+
+    @Test
+    void amp() {
+        assertThat(escape("&")).isEqualTo("&amp;");
+    }
+
+    @Test
+    void quote() {
+        assertThat(escape("\"")).isEqualTo("&#34;");
+    }
+
+    @Test
+    void singleQuote() {
+        assertThat(escape("'")).isEqualTo("&#39;");
+    }
+
+    @Test
+    void many() {
+        assertThat(escape("''''\"\"\"\":-)")).isEqualTo("&#39;&#39;&#39;&#39;&#34;&#34;&#34;&#34;:-)");
+    }
+
+    private String escape(String value) {
+        StringOutput output = new StringOutput();
+        Escape.htmlAttribute(value, output);
+        return output.toString();
+    }
+}

--- a/jte/src/test/java/gg/jte/html/escape/Escape_HtmlContentTest.java
+++ b/jte/src/test/java/gg/jte/html/escape/Escape_HtmlContentTest.java
@@ -1,0 +1,50 @@
+package gg.jte.html.escape;
+
+import gg.jte.output.StringOutput;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Escape_HtmlContentTest {
+
+    @Test
+    void empty() {
+        assertThat(escape("")).isEqualTo("");
+    }
+
+    @Test
+    void nothingToEscape() {
+        assertThat(escape("script")).isEqualTo("script");
+    }
+
+    @Test
+    void amp() {
+        assertThat(escape("&")).isEqualTo("&amp;");
+    }
+
+    @Test
+    void lt() {
+        assertThat(escape("<")).isEqualTo("&lt;");
+    }
+
+    @Test
+    void gt() {
+        assertThat(escape(">")).isEqualTo("&gt;");
+    }
+
+    @Test
+    void script() {
+        assertThat(escape("<script>")).isEqualTo("&lt;script&gt;");
+    }
+
+    @Test
+    void many() {
+        assertThat(escape("<<<<&&&&>>>>:-)")).isEqualTo("&lt;&lt;&lt;&lt;&amp;&amp;&amp;&amp;&gt;&gt;&gt;&gt;:-)");
+    }
+
+    private String escape(String value) {
+        StringOutput output = new StringOutput();
+        Escape.htmlContent(value, output);
+        return output.toString();
+    }
+}

--- a/jte/src/test/java/gg/jte/html/escape/Escape_JavaScriptAttributeTest.java
+++ b/jte/src/test/java/gg/jte/html/escape/Escape_JavaScriptAttributeTest.java
@@ -1,0 +1,70 @@
+package gg.jte.html.escape;
+
+import gg.jte.output.StringOutput;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Escape_JavaScriptAttributeTest {
+
+    @Test
+    void empty() {
+        assertThat(escape("")).isEqualTo("");
+    }
+
+    @Test
+    void nothingToEscape() {
+        assertThat(escape("script")).isEqualTo("script");
+    }
+
+    @Test
+    void quote() {
+        assertThat(escape("\"")).isEqualTo("\\x22");
+    }
+
+    @Test
+    void singleQuote() {
+        assertThat(escape("'")).isEqualTo("\\x27");
+    }
+
+    @Test
+    void backslash() {
+        assertThat(escape("\\")).isEqualTo("\\\\");
+    }
+
+    @Test
+    void linebreak() {
+        assertThat(escape("\n")).isEqualTo("\\n");
+    }
+
+    @Test
+    void linebreak_windows() {
+        assertThat(escape("\r")).isEqualTo("\\r");
+    }
+
+    @Test
+    void tab() {
+        assertThat(escape("\t")).isEqualTo("\\t");
+    }
+
+    @Test
+    void formFeed() {
+        assertThat(escape("\f")).isEqualTo("\\f");
+    }
+
+    @Test
+    void backspace() {
+        assertThat(escape("\b")).isEqualTo("\\b");
+    }
+
+    @Test
+    void many() {
+        assertThat(escape("'''':-)")).isEqualTo("\\x27\\x27\\x27\\x27:-)");
+    }
+
+    private String escape(String value) {
+        StringOutput output = new StringOutput();
+        Escape.javaScriptAttribute(value, output);
+        return output.toString();
+    }
+}

--- a/jte/src/test/java/gg/jte/html/escape/Escape_JavaScriptBlockTest.java
+++ b/jte/src/test/java/gg/jte/html/escape/Escape_JavaScriptBlockTest.java
@@ -1,0 +1,93 @@
+package gg.jte.html.escape;
+
+import gg.jte.output.StringOutput;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Notes from OWASP Java Encoder:
+ *
+ * in <script> blocks, we need to prevent the browser from seeing
+ * "</anything>" and "<!--". To do so we escape "/" as "\/" and
+ * escape "-" as "\-".  Both could be solved with a hex encoding
+ * on "<" but we figure "<" appears often in script strings and
+ * the backslash encoding is more readable than a hex encoding.
+ * (And note, a backslash encoding would not prevent the exploits
+ * on "</...>" and "<!--".
+ * In short "</script>" is escaped as "<\/script>" and "<!--" is
+ * escaped as "<!\-\-".
+ */
+public class Escape_JavaScriptBlockTest {
+
+    @Test
+    void empty() {
+        assertThat(escape("")).isEqualTo("");
+    }
+
+    @Test
+    void nothingToEscape() {
+        assertThat(escape("script")).isEqualTo("script");
+    }
+
+    @Test
+    void quote() {
+        assertThat(escape("\"")).isEqualTo("\\\"");
+    }
+
+    @Test
+    void singleQuote() {
+        assertThat(escape("'")).isEqualTo("\\'");
+    }
+
+    @Test
+    void slash() {
+        assertThat(escape("/")).isEqualTo("\\/");
+    }
+
+    @Test
+    void minus() {
+        assertThat(escape("-")).isEqualTo("\\-");
+    }
+
+    @Test
+    void backslash() {
+        assertThat(escape("\\")).isEqualTo("\\\\");
+    }
+
+    @Test
+    void linebreak() {
+        assertThat(escape("\n")).isEqualTo("\\n");
+    }
+
+    @Test
+    void linebreak_windows() {
+        assertThat(escape("\r")).isEqualTo("\\r");
+    }
+
+    @Test
+    void tab() {
+        assertThat(escape("\t")).isEqualTo("\\t");
+    }
+
+    @Test
+    void formFeed() {
+        assertThat(escape("\f")).isEqualTo("\\f");
+    }
+
+    @Test
+    void backspace() {
+        assertThat(escape("\b")).isEqualTo("\\b");
+    }
+
+    @Test
+    void many() {
+        assertThat(escape("'''':-)")).isEqualTo("\\'\\'\\'\\':\\-)");
+    }
+
+    private String escape(String value) {
+        StringOutput output = new StringOutput();
+        Escape.javaScriptBlock(value, output);
+        return output.toString();
+    }
+}

--- a/jte/src/test/java/gg/jte/output/AbstractTemplateOutputTest.java
+++ b/jte/src/test/java/gg/jte/output/AbstractTemplateOutputTest.java
@@ -5,14 +5,28 @@ import gg.jte.ContentType;
 import gg.jte.TemplateOutput;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 public abstract class AbstractTemplateOutputTest<T extends TemplateOutput> {
     T output = createTemplateOutput();
 
     abstract T createTemplateOutput();
 
     abstract void thenOutputIs(String expected);
+
+    @Test
+    void writeString() {
+        output.writeContent("foo");
+        output.writeContent("bar");
+
+        thenOutputIs("foobar");
+    }
+
+    @Test
+    void writeSubstring() {
+        output.writeContent("foobar", 0, 3);
+        output.writeContent("foobar", 3, 6);
+
+        thenOutputIs("foobar");
+    }
 
     @Test
     void writeBoolean() {
@@ -99,53 +113,6 @@ public abstract class AbstractTemplateOutputTest<T extends TemplateOutput> {
         output.writeUserContent((Number) null);
         output.writeUserContent((Character) null);
         thenOutputIs("");
-    }
-
-    @Test
-    void writer_charArray() throws IOException {
-        char[] chars = "The quick brown fox...".toCharArray();
-        output.getWriter().write(chars);
-
-        thenOutputIs("The quick brown fox...");
-    }
-
-    @Test
-    void writer_charArrayWithOffset() throws IOException {
-        char[] chars = "The quick brown fox...".toCharArray();
-        output.getWriter().write(chars, 4, 5);
-        output.getWriter().write(chars, 16, 3);
-
-        thenOutputIs("quickfox");
-    }
-
-    @Test
-    void writer_char() throws IOException {
-        output.getWriter().write('f');
-        output.getWriter().write('o');
-        output.getWriter().write('x');
-
-        thenOutputIs("fox");
-    }
-
-    @Test
-    void writer_string() throws IOException {
-        output.getWriter().write("The quick brown fox...");
-        thenOutputIs("The quick brown fox...");
-    }
-
-    @Test
-    void writer_stringWithOffset() throws IOException {
-        String s = "The quick brown fox...";
-        output.getWriter().write(s, 4, 5);
-        output.getWriter().write(s, 16, 3);
-
-        thenOutputIs("quickfox");
-    }
-
-    @Test
-    void writer_unusedMethodsAreNoops() throws IOException {
-        output.getWriter().flush();
-        output.getWriter().close();
     }
 
     public enum EnumWithToStringOverride {

--- a/jte/src/test/java/gg/jte/output/Utf8ByteArrayOutputTest.java
+++ b/jte/src/test/java/gg/jte/output/Utf8ByteArrayOutputTest.java
@@ -2,7 +2,6 @@ package gg.jte.output;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,6 +22,12 @@ public class Utf8ByteArrayOutputTest extends AbstractTemplateOutputTest<Utf8Byte
     void string() {
         output.writeContent("Hello");
         thenOutputIs("Hello");
+    }
+
+    @Test
+    void substring() {
+        output.writeContent("Hello", 1, 3);
+        thenOutputIs("el");
     }
 
     @Test
@@ -78,8 +83,8 @@ public class Utf8ByteArrayOutputTest extends AbstractTemplateOutputTest<Utf8Byte
     }
 
     @Test
-    void utf8_0x00() throws IOException {
-        output.write((char)0);
+    void utf8_0x00() {
+        output.writeUserContent((char)0);
         thenOutputIs("\u0000");
     }
 

--- a/jte/src/test/java/gg/jte/output/Utf8ByteOutputTest.java
+++ b/jte/src/test/java/gg/jte/output/Utf8ByteOutputTest.java
@@ -40,6 +40,12 @@ public class Utf8ByteOutputTest extends AbstractTemplateOutputTest<Utf8ByteOutpu
     }
 
     @Test
+    void substring() {
+        output.writeContent("Hello", 1, 3);
+        thenOutputIs("el");
+    }
+
+    @Test
     void outputs() {
         output.writeContent("\uD83D\uDCA9");
         output.writeContent(" says ");
@@ -81,7 +87,7 @@ public class Utf8ByteOutputTest extends AbstractTemplateOutputTest<Utf8ByteOutpu
 
     @Test
     void utf8_0x00() {
-        output.write(0);
+        output.writeUserContent((char)0);
         thenOutputIs("\u0000");
     }
 
@@ -123,22 +129,10 @@ public class Utf8ByteOutputTest extends AbstractTemplateOutputTest<Utf8ByteOutpu
 
     @Test
     void utf8_missingLowSurrogate() {
-        output.write(new char[]{'\uD83D'});
-        output.write(new char[0]); // Will be ignored
-        output.write(new char[]{'\uDCA9'}); // Will continue, where the char array was split
-        thenOutputIs("\uD83D\uDCA9");
-    }
-
-    @Test
-    void utf8_missingLowSurrogate_reallyMissing() {
-        output.write(new char[]{'\uD83D'});
-        output.write(new char[]{'f', 'o', 'o'});
-        thenOutputIs("�foo");
-    }
-
-    @Test
-    void utf8_missingLowSurrogate_reallyMissingInOneBuffer() {
-        output.write(new char[]{'\uD83D', 'f', 'o', 'o'});
+        output.writeUserContent('\uD83D');
+        output.writeUserContent('f');
+        output.writeUserContent('o');
+        output.writeUserContent('o');
         thenOutputIs("�foo");
     }
 


### PR DESCRIPTION
Benchmarks as in #225 have shown that OWASP Java Encoder is slower than expected for output escaping. In order to use the faster methods of OWASP encoder, all template outputs had to provide an instance of the rather ancient and clumsy `Writer` interface, that really should not be part of the public API of `TemplateOutput`.

This PR replaces the four methods we currently use from the OWASP Java Encoder project by optimized methods that work directly on a `TemplateOutput`:
- `org.owasp.encoder.Encode.forHtmlContent` -> `gg.jte.html.escape.Escape.htmlContent`
- `org.owasp.encoder.Encode.forHtmlAttribute` -> `gg.jte.html.escape.Escape.htmlAttribute`
- `org.owasp.encoder.Encode.forJavaScriptBlock` -> `gg.jte.html.escape.Escape.javaScriptBlock`
- `org.owasp.encoder.Encode.forJavaScriptAttribute` -> `gg.jte.html.escape.Escape.javaScriptAttribute`

All methods should behave exactly like their OWASP counterparts.

After this patch is merged, jte will be free from external dependencies.