### PR TITLE
Models custom annotation

### DIFF
--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteExtension.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteExtension.java
@@ -47,7 +47,7 @@ public abstract class JteExtension
         getJteExtensions().add(extensionSettings);
     }
 
-    public void jtExtension(String className, Action<JteExtensionSettings> action) {
+    public void jteExtension(String className, Action<JteExtensionSettings> action) {
         JteExtensionSettings extensionSettings = objectFactory.newInstance(JteExtensionSettings.class);
         extensionSettings.getClassName().set(className);
         getJteExtensions().add(extensionSettings);

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteExtensionSettings.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteExtensionSettings.java
@@ -7,12 +7,19 @@ import org.gradle.api.provider.Provider;
 public abstract class JteExtensionSettings {
     public abstract Property<String> getClassName();
     public abstract MapProperty<String, String> getProperties();
-
     public void property(String key, String value) {
         getProperties().put(key, value);
     }
-
     public void property(String key, Provider<String> valueProvider) {
         getProperties().put(key, valueProvider);
+    }
+
+    // groovy assignment support
+    public void propertyMissing(String key, String value) {
+        property(key, value);
+    }
+
+    public void propertyMissing(String key, Provider<String> valueProvider) {
+        property(key, valueProvider);
     }
 }

--- a/jte-models/README.md
+++ b/jte-models/README.md
@@ -68,8 +68,8 @@ jte {
     // or to add annotations to generated classes:
     /*
     jteExtension('gg.jte.models.generator.ModelExtension') {
-        property('interfaceAnnotation', '@foo.bar.MyAnnotation')
-        property('implementationAnnotation', '@foo.bar.MyAnnotation')
+        interfaceAnnotation = '@foo.bar.MyAnnotation'
+        implementationAnnotation = '@foo.bar.MyAnnotation'
     }
      */
 }

--- a/jte-models/README.md
+++ b/jte-models/README.md
@@ -20,6 +20,12 @@ To use jte-models, set up your build script to include one of these:
                     <extensions>
                         <extension>
                             <className>gg.jte.models.generator.ModelExtension</className>
+                            <!-- optional settings to include annotations on generated classes:
+                            <settings>
+                                <interfaceAnnotation>@foo.bar.MyAnnotation</interfaceAnnotation>
+                                <implementationAnnotation>@foo.bar.MyAnnotation</implementationAnnotation>
+                            </settings>
+                            -->
                         </extension>
                     </extensions>
                 </configuration>
@@ -59,6 +65,13 @@ jte {
     generate()
     binaryStaticContent = true
     jteExtension 'gg.jte.models.generator.ModelExtension'
+    // or to add annotations to generated classes:
+    /*
+    jteExtension('gg.jte.models.generator.ModelExtension') {
+        property('interfaceAnnotation', '@foo.bar.MyAnnotation')
+        property('implementationAnnotation', '@foo.bar.MyAnnotation')
+    }
+     */
 }
 
 ```
@@ -81,6 +94,13 @@ jte {
     generate()
     binaryStaticContent.set(true)
     jteExtension("gg.jte.models.generator.ModelExtension")
+    // or to add annotations to generated classes:
+    /*
+    jteExtension("gg.jte.models.generator.ModelExtension") {
+        property("interfaceAnnotation", "@foo.bar.MyAnnotation")
+        property("implementationAnnotation", "@foo.bar.MyAnnotation")
+    }
+     */
 }
 
 ```

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
@@ -1,0 +1,19 @@
+package gg.jte.models.generator;
+
+import java.util.Map;
+
+public class ModelConfig {
+    private final Map<String, String> map;
+
+    public ModelConfig(Map<String, String> value) {
+        map = value;
+    }
+
+    public String interfaceAnnotation() {
+        return map.getOrDefault("interfaceAnnotation", "");
+    }
+
+    public String implementationAnnotation() {
+        return map.getOrDefault("implementationAnnotation", "");
+    }
+}

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
@@ -8,15 +8,24 @@ import gg.jte.extension.api.TemplateDescription;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @SuppressWarnings("unused")
 public class ModelExtension implements JteExtension {
+    private ModelConfig modelConfig = new ModelConfig(Map.of());
+
     @Override
     public String name() {
         return "Generate type-safe model facade for templates";
+    }
+
+    @Override
+    public JteExtension init(Map<String, String> value) {
+        modelConfig = new ModelConfig(value);
+        return this;
     }
 
     @Override
@@ -26,7 +35,7 @@ public class ModelExtension implements JteExtension {
                 new ModelGenerator(engine, "interfacetemplates", "Templates", "Templates"),
                 new ModelGenerator(engine, "statictemplates", "StaticTemplates", "Templates"),
                 new ModelGenerator(engine, "dynamictemplates", "DynamicTemplates", "Templates")
-        ).map(g -> g.generate(config, templateDescriptions))
+        ).map(g -> g.generate(config, templateDescriptions, modelConfig))
                 .collect(Collectors.toList());
     }
 }

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelGenerator.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelGenerator.java
@@ -30,7 +30,7 @@ public class ModelGenerator {
         this.interfaceName = interfaceName;
     }
 
-    public Path generate(JteConfig config, Set<TemplateDescription> templateDescriptions) {
+    public Path generate(JteConfig config, Set<TemplateDescription> templateDescriptions, ModelConfig modelConfig) {
         Path sourceFilePath = config.generatedSourcesRoot()
                 .resolve(config.packageName().replace('.', '/'))
                 .resolve(targetClassName + ".java");
@@ -46,6 +46,7 @@ public class ModelGenerator {
                 paramMap.put("config", config);
                 paramMap.put("templates", templateDescriptions);
                 paramMap.put("imports", imports);
+                paramMap.put("modelConfig", modelConfig);
                 engine.render(templateSubDirectory + "/main.jte", paramMap, new SquashBlanksOutput(new WriterOutput(w)));
             }
         } catch (IOException e) {

--- a/jte-models/src/main/jte/dynamictemplates/main.jte
+++ b/jte-models/src/main/jte/dynamictemplates/main.jte
@@ -1,4 +1,5 @@
 @import gg.jte.extension.api.*
+@import gg.jte.models.generator.ModelConfig
 @import java.util.Set
 
 @param String targetClassName
@@ -6,6 +7,8 @@
 @param JteConfig config
 @param Set<TemplateDescription> templates
 @param Iterable<String> imports
+@param ModelConfig modelConfig
+
 
 package ${config.packageName()};
 
@@ -16,6 +19,7 @@ import gg.jte.models.runtime.*;
 @for(String imp: imports)
     import ${imp};@endfor
 
+${modelConfig.implementationAnnotation()}
 public class ${targetClassName} implements ${interfaceName} {
     private final TemplateEngine engine;
 

--- a/jte-models/src/main/jte/dynamictemplates/main.jte
+++ b/jte-models/src/main/jte/dynamictemplates/main.jte
@@ -17,7 +17,8 @@ import java.util.Map;
 import java.util.HashMap;
 import gg.jte.models.runtime.*;
 @for(String imp: imports)
-    import ${imp};@endfor
+    import ${imp};
+@endfor
 
 ${modelConfig.implementationAnnotation()}
 public class ${targetClassName} implements ${interfaceName} {

--- a/jte-models/src/main/jte/interfacetemplates/main.jte
+++ b/jte-models/src/main/jte/interfacetemplates/main.jte
@@ -10,8 +10,9 @@
 
 package ${config.packageName()};
 import gg.jte.models.runtime.*;
-    @for(String imp: imports)
-import ${imp};@endfor
+@for(String imp: imports)
+import ${imp};
+@endfor
 
 ${modelConfig.interfaceAnnotation()}
 public interface ${targetClassName} {

--- a/jte-models/src/main/jte/interfacetemplates/main.jte
+++ b/jte-models/src/main/jte/interfacetemplates/main.jte
@@ -1,16 +1,19 @@
 @import gg.jte.extension.api.*
+@import gg.jte.models.generator.ModelConfig
 @import java.util.Set
 
 @param String targetClassName
 @param JteConfig config
 @param Set<TemplateDescription> templates
 @param Iterable<String> imports
+@param ModelConfig modelConfig
 
 package ${config.packageName()};
 import gg.jte.models.runtime.*;
     @for(String imp: imports)
 import ${imp};@endfor
 
+${modelConfig.interfaceAnnotation()}
 public interface ${targetClassName} {
     @for(TemplateDescription template: templates)
         @template.interfacetemplates.method(template = template)

--- a/jte-models/src/main/jte/statictemplates/main.jte
+++ b/jte-models/src/main/jte/statictemplates/main.jte
@@ -17,7 +17,8 @@ import gg.jte.TemplateOutput;
 import gg.jte.html.HtmlInterceptor;
 import gg.jte.html.HtmlTemplateOutput;
 @for(String imp: imports)
-    import ${imp};@endfor
+    import ${imp};
+@endfor
 
 ${modelConfig.implementationAnnotation()}
 public class ${targetClassName} implements ${interfaceName} {

--- a/jte-models/src/main/jte/statictemplates/main.jte
+++ b/jte-models/src/main/jte/statictemplates/main.jte
@@ -1,4 +1,5 @@
 @import gg.jte.extension.api.*
+@import gg.jte.models.generator.ModelConfig
 @import java.util.Set
 
 @param String targetClassName
@@ -6,6 +7,7 @@
 @param JteConfig config
 @param Set<TemplateDescription> templates
 @param Iterable<String> imports
+@param ModelConfig modelConfig
 
 package ${config.packageName()};
 
@@ -17,7 +19,7 @@ import gg.jte.html.HtmlTemplateOutput;
 @for(String imp: imports)
     import ${imp};@endfor
 
-
+${modelConfig.implementationAnnotation()}
 public class ${targetClassName} implements ${interfaceName} {
     @for(TemplateDescription template: templates)
         @template.statictemplates.method(config = config, template = template)

--- a/test/jte-runtime-cp-test-models-gradle/build.gradle
+++ b/test/jte-runtime-cp-test-models-gradle/build.gradle
@@ -31,7 +31,7 @@ jte {
     generate()
     binaryStaticContent = true
     jteExtension('gg.jte.models.generator.ModelExtension') {
-        property('implementationAnnotation', '@test.Dummy')
+        implementationAnnotation = '@test.Dummy'
     }
 }
 

--- a/test/jte-runtime-cp-test-models-gradle/build.gradle
+++ b/test/jte-runtime-cp-test-models-gradle/build.gradle
@@ -30,7 +30,9 @@ dependencies {
 jte {
     generate()
     binaryStaticContent = true
-    jteExtension 'gg.jte.models.generator.ModelExtension'
+    jteExtension('gg.jte.models.generator.ModelExtension') {
+        property('implementationAnnotation', '@test.Dummy')
+    }
 }
 
 graalvmNative {

--- a/test/jte-runtime-cp-test-models-gradle/src/main/java/test/Dummy.java
+++ b/test/jte-runtime-cp-test-models-gradle/src/main/java/test/Dummy.java
@@ -1,0 +1,13 @@
+package test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Dummy {
+}

--- a/test/jte-runtime-cp-test-models-gradle/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/test/jte-runtime-cp-test-models-gradle/src/test/java/gg/jte/TemplateEngineTest.java
@@ -10,8 +10,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import test.Dummy;
 import test.Model;
 
+import java.lang.annotation.Annotation;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,5 +78,13 @@ public class TemplateEngineTest {
     void nestedContent(Templates templates) {
         String output = templates.layout(templates.helloWorld(model)).render();
         assertThat(output).containsIgnoringWhitespaces("Header", "Hello World", "Footer");
+    }
+
+    @ParameterizedTest
+    @MethodSource("templates")
+    void hasAnnotation(Templates templates) {
+        Class<? extends Templates> clazz = templates.getClass();
+        Annotation[] annotations = clazz.getDeclaredAnnotations();
+        assertThat(annotations).anyMatch(a -> a instanceof Dummy);
     }
 }

--- a/test/jte-runtime-cp-test-models/pom.xml
+++ b/test/jte-runtime-cp-test-models/pom.xml
@@ -87,6 +87,9 @@
                     <extensions>
                         <extension>
                             <className>gg.jte.models.generator.ModelExtension</className>
+                            <settings>
+                                <implementationAnnotation>@test.Dummy</implementationAnnotation>
+                            </settings>
                         </extension>
                     </extensions>
                 </configuration>

--- a/test/jte-runtime-cp-test-models/src/main/java/test/Dummy.java
+++ b/test/jte-runtime-cp-test-models/src/main/java/test/Dummy.java
@@ -1,0 +1,13 @@
+package test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Dummy {
+}

--- a/test/jte-runtime-cp-test-models/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/test/jte-runtime-cp-test-models/src/test/java/gg/jte/TemplateEngineTest.java
@@ -10,8 +10,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import test.Dummy;
 import test.Model;
 
+import java.lang.annotation.Annotation;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,5 +78,13 @@ public class TemplateEngineTest {
     void nestedContent(Templates templates) {
         String output = templates.layout(templates.helloWorld(model)).render();
         assertThat(output).containsIgnoringWhitespaces("Header", "Hello World", "Footer");
+    }
+
+    @ParameterizedTest
+    @MethodSource("templates")
+    void hasAnnotation(Templates templates) {
+        Class<? extends Templates> clazz = templates.getClass();
+        Annotation[] annotations = clazz.getDeclaredAnnotations();
+        assertThat(annotations).anyMatch(a -> a instanceof Dummy);
     }
 }


### PR DESCRIPTION
Adds some optional properties to the jte-models extension, to enable adding an annotation to the generated interface or implementation classes. Added to test cases and README.