### PR TITLE
Add CompositeCodeResolver added to allow template reading in several places

### DIFF
--- a/jte/src/main/java/gg/jte/resolve/CompositeCodeResolver.java
+++ b/jte/src/main/java/gg/jte/resolve/CompositeCodeResolver.java
@@ -1,0 +1,68 @@
+package gg.jte.resolve;
+
+
+import gg.jte.CodeResolver;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Resolves template code from multiple other resolvers
+ */
+public class CompositeCodeResolver implements CodeResolver {
+
+    private final List<CodeResolver> codeResolvers;
+
+    public CompositeCodeResolver(List<CodeResolver> codeResolvers) {
+        this.codeResolvers = codeResolvers;
+    }
+
+    @Override
+    public String resolve(String name) {
+        var content = "";
+        for (CodeResolver codeResolver : this.codeResolvers) {
+            try {
+                String resolve = codeResolver.resolve(name);
+                if(Objects.nonNull(resolve)){
+                    content = resolve;
+                }
+            } catch (Exception ex) {
+                // ignore
+            }
+        }
+        if(!content.isEmpty())
+            return content;
+        throw new UncheckedIOException(new IOException("Could not find template " + name));
+    }
+
+    @Override
+    public long getLastModified(String name) {
+        long lastModified = 0;
+        for (CodeResolver codeResolver : this.codeResolvers) {
+            try {
+                lastModified = codeResolver.getLastModified(name);
+                if(lastModified > 0)
+                    return lastModified;
+            } catch (Exception ex) {
+                lastModified = 0;
+            }
+        }
+        return lastModified;
+    }
+
+    @Override
+    public List<String> resolveAllTemplateNames() {
+        List<String> allTemplateNames = new ArrayList<>();
+        for (CodeResolver codeResolver : this.codeResolvers) {
+            try {
+                allTemplateNames.addAll(codeResolver.resolveAllTemplateNames());
+            } catch (Exception ex) {
+                // ignore
+            }
+        }
+        return allTemplateNames;
+    }
+}

--- a/jte/src/main/java/gg/jte/resolve/CompositeCodeResolver.java
+++ b/jte/src/main/java/gg/jte/resolve/CompositeCodeResolver.java
@@ -3,11 +3,8 @@ package gg.jte.resolve;
 
 import gg.jte.CodeResolver;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Resolves template code from multiple other resolvers
@@ -20,22 +17,24 @@ public class CompositeCodeResolver implements CodeResolver {
         this.codeResolvers = codeResolvers;
     }
 
+    public CompositeCodeResolver(CodeResolver... codeResolvers) {
+        this(List.of(codeResolvers));
+    }
+
     @Override
     public String resolve(String name) {
-        var content = "";
+        String content = null;
         for (CodeResolver codeResolver : this.codeResolvers) {
             try {
                 String resolve = codeResolver.resolve(name);
-                if(Objects.nonNull(resolve)){
+                if(resolve != null){
                     content = resolve;
                 }
             } catch (Exception ex) {
                 // ignore
             }
         }
-        if(!content.isEmpty())
-            return content;
-        throw new UncheckedIOException(new IOException("Could not find template " + name));
+        return content;
     }
 
     @Override

--- a/jte/src/test/java/gg/jte/resolve/CompositeCodeResolverTest.java
+++ b/jte/src/test/java/gg/jte/resolve/CompositeCodeResolverTest.java
@@ -1,0 +1,59 @@
+package gg.jte.resolve;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CompositeCodeResolverTest {
+
+    CompositeCodeResolver compositeCodeResolver;
+
+    @Test
+    void resolveTemplate() {
+        ResourceCodeResolver resourceCodeResolver = new ResourceCodeResolver("benchmark");
+        DirectoryCodeResolver directoryCodeResolver = new DirectoryCodeResolver(Paths.get("src/test/resources/benchmark"));
+        compositeCodeResolver = new CompositeCodeResolver(
+                List.of(resourceCodeResolver, directoryCodeResolver)
+        );
+
+        String welcomeTemplateResolve = compositeCodeResolver.resolve("welcome.jte");
+        String pageTemplateResolve = compositeCodeResolver.resolve("layout/page.jte");
+
+        Assertions.assertNotNull(welcomeTemplateResolve);
+        Assertions.assertNotNull(pageTemplateResolve);
+    }
+
+
+    @Test
+    void getLastModifiedTemplate() {
+        ResourceCodeResolver resourceCodeResolver = new ResourceCodeResolver("benchmark");
+        DirectoryCodeResolver directoryCodeResolver = new DirectoryCodeResolver(Paths.get("src/test/resources/benchmark"));
+        compositeCodeResolver = new CompositeCodeResolver(
+                List.of(resourceCodeResolver, directoryCodeResolver)
+        );
+
+        long welcomeTemplateLastModified = compositeCodeResolver.getLastModified("welcome.jte");
+        long pageTemplateLastModified = compositeCodeResolver.getLastModified("layout/page.jte");
+
+        Assertions.assertTrue(welcomeTemplateLastModified > 0);
+        Assertions.assertTrue(pageTemplateLastModified > 0);
+    }
+
+    @Test
+    void resolveAllTemplateNames() {
+        ResourceCodeResolver resourceCodeResolver = new ResourceCodeResolver("benchmark");
+        DirectoryCodeResolver directoryCodeResolver = new DirectoryCodeResolver(Paths.get("src/test/resources/benchmark"));
+        compositeCodeResolver = new CompositeCodeResolver(
+                List.of(resourceCodeResolver, directoryCodeResolver)
+        );
+
+        List<String> allTemplateNames = compositeCodeResolver.resolveAllTemplateNames();
+
+        Assertions.assertTrue(allTemplateNames.contains("welcome.jte"));
+        Assertions.assertTrue(allTemplateNames.contains("layout/page.jte"));
+    }
+}

--- a/jte/src/test/java/gg/jte/resolve/CompositeCodeResolverTest.java
+++ b/jte/src/test/java/gg/jte/resolve/CompositeCodeResolverTest.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 public class CompositeCodeResolverTest {
 
     CompositeCodeResolver compositeCodeResolver;


### PR DESCRIPTION
I recently had a problem with JTE when using it with the Spring View Component library in a personal project.
I needed a CodeResolver that could read templates in different places.

I therefore propose this pull request so that jte can take care of this need.
For details on the difficulty I had see the following [issue](https://github.com/tschuehly/spring-view-component/issues/8)
