### PR TITLE
Support Dynamic Html Attribute Names

### DIFF
--- a/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
+++ b/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
@@ -319,7 +319,7 @@ public class KotlinCodeGenerator implements CodeGenerator {
     @Override
     public void onHtmlTagAttributeCodePart(int depth, String codePart, String tagName, String attributeName) {
         writeIndentation(depth);
-        kotlinCode.append("jteOutput.setContext(\"").append(tagName).append("\", \"").append(attributeName).append("\")\n");
+        kotlinCode.append("jteOutput.setContext(\"").append(tagName).append("\", \"").appendEscaped(attributeName).append("\")\n");
 
         writeCodePart(depth, codePart);
 

--- a/jte-runtime/src/main/java/gg/jte/html/policy/PreventOutputInTagsAndAttributes.java
+++ b/jte-runtime/src/main/java/gg/jte/html/policy/PreventOutputInTagsAndAttributes.java
@@ -7,6 +7,16 @@ import gg.jte.html.HtmlTag;
 
 public class PreventOutputInTagsAndAttributes implements HtmlPolicy {
 
+    private final boolean preventExpressionsInAttributes;
+
+    public PreventOutputInTagsAndAttributes() {
+        this(true);
+    }
+
+    public PreventOutputInTagsAndAttributes(boolean preventExpressionsInAttributes) {
+        this.preventExpressionsInAttributes = preventExpressionsInAttributes;
+    }
+
     @Override
     public void validateHtmlTag(HtmlTag htmlTag) throws HtmlPolicyException {
         if ( htmlTag.getName().contains("${") ) {
@@ -16,7 +26,7 @@ public class PreventOutputInTagsAndAttributes implements HtmlPolicy {
 
     @Override
     public void validateHtmlAttribute(HtmlTag htmlTag, HtmlAttribute htmlAttribute) throws HtmlPolicyException {
-        if ( htmlAttribute.getName().contains("${") ) {
+        if ( preventExpressionsInAttributes && htmlAttribute.getName().contains("${") ) {
             throw new HtmlPolicyException("Illegal HTML attribute name " + htmlAttribute.getName() + "! Expressions in HTML attribute names are not allowed.");
         }
 

--- a/jte/src/main/java/gg/jte/compiler/TemplateParser.java
+++ b/jte/src/main/java/gg/jte/compiler/TemplateParser.java
@@ -704,7 +704,7 @@ public final class TemplateParser {
                 } else if (currentAttribute.quoteCount == 2) {
                     currentAttribute.value = templateCode.substring(currentAttribute.valueStartIndex, i);
 
-                    if (currentAttribute.containsSingleOutput) {
+                    if (currentAttribute.isSmartAttribute()) {
                         extractTextPart(getLastWhitespaceIndex(currentAttribute.startIndex - 1), Mode.Code);
                         lastIndex = i + 1;
 
@@ -760,7 +760,7 @@ public final class TemplateParser {
 
                     currentHtmlTag.attributes.add(attribute);
 
-                    if (attribute.containsSingleOutput) {
+                    if (attribute.isSmartAttribute()) {
                         outputPrevented = true;
                     }
 
@@ -1228,6 +1228,10 @@ public final class TemplateParser {
         @Override
         public boolean isBoolean() {
             return bool;
+        }
+
+        public boolean isSmartAttribute() {
+            return containsSingleOutput && !name.contains("${") && !name.contains("$unsafe{");
         }
     }
 }

--- a/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
@@ -2,11 +2,12 @@ package gg.jte;
 
 import gg.jte.html.HtmlTemplateOutput;
 import gg.jte.html.OwaspHtmlPolicy;
-import gg.jte.html.policy.PreventInlineEventHandlers;
-import gg.jte.html.policy.PreventSingleQuotedAttributes;
+import gg.jte.html.policy.*;
 import gg.jte.output.StringOutput;
 import gg.jte.runtime.TemplateUtils;
 import gg.jte.support.LocalizationSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -1610,6 +1611,51 @@ public class TemplateEngine_HtmlOutputEscapingTest {
         templateEngine.render("template.jte", TemplateUtils.toMap("localizer", localizer), output);
 
         assertThat(output.toString()).isEqualTo("<span>Hello? <a style=\"color: foo;\">Click here</a></span>");
+    }
+
+    @Nested
+    class DynamicAttributesForHotwire {
+
+        class HotwireHtmlPolicy extends PolicyGroup {
+            HotwireHtmlPolicy() {
+                addPolicy(new PreventUppercaseTagsAndAttributes());
+                addPolicy(new PreventOutputInTagsAndAttributes(false));
+                addPolicy(new PreventUnquotedAttributes());
+            }
+        }
+
+        @BeforeEach
+        void setUp() {
+            templateEngine.setHtmlPolicy(new HotwireHtmlPolicy());
+        }
+
+        @Test
+        void attributes_dynamicNameForHotwire() {
+            codeResolver.givenCode("template.jte", "@param String controller\n@param String target\n<div data-controller=\"hello\">\n<input data-${controller}-target=\"${target}\"/></div>");
+
+            templateEngine.render("template.jte", TemplateUtils.toMap("controller", "hello", "target", "name"), output);
+
+            assertThat(output.toString()).isEqualTo("<div data-controller=\"hello\">\n<input data-hello-target=\"name\"/></div>");
+        }
+
+        @Test
+        void attributes_dynamicNameForHotwire_unsafe() {
+            codeResolver.givenCode("template.jte", "@param String controller\n@param String target\n<div data-controller=\"hello\">\n<input data-$unsafe{controller}-target=\"${target}\"/></div>");
+
+            templateEngine.render("template.jte", TemplateUtils.toMap("controller", "hello", "target", "name"), output);
+
+            assertThat(output.toString()).isEqualTo("<div data-controller=\"hello\">\n<input data-hello-target=\"name\"/></div>");
+        }
+
+        @Test
+        void attributes_dynamicNameForHotwire_unsafe_worksWithDefaultPolicyToo() {
+            templateEngine.setHtmlPolicy(new OwaspHtmlPolicy());
+            codeResolver.givenCode("template.jte", "@param String controller\n@param String target\n<div data-controller=\"hello\">\n<input data-$unsafe{controller}-target=\"${target}\"/></div>");
+
+            templateEngine.render("template.jte", TemplateUtils.toMap("controller", "hello", "target", "name"), output);
+
+            assertThat(output.toString()).isEqualTo("<div data-controller=\"hello\">\n<input data-hello-target=\"name\"/></div>");
+        }
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
For hotwire development it is required to have dynamic attribute names in certain cases. See issue #254

This is prevented by `OwaspHtmlPolicy`, or more specifically the policy `PreventOutputInTagsAndAttributes`. This is because attribute names are not a safe slot to put untrusted user input into. There are various ways to escape the attribute name.

This PR fixes a bug in jte, so that correct output is generated, if this policy is disabled by the user and dynamic output is used in an attribute name.

There are currently two ways to achieve this:
- Custom HTML Policy that disables or weakens the `PreventOutputInTagsAndAttributes` policy
- Using `$unsafe` for the dynamic output in the attribute name

@wyaeld during implementation I noticed that my initial recommendation to disable the `PreventOutputInTagsAndAttributes` policy entirely does remove a few more policies that are quite useful and I think that most users will want to have, such as preventing dynamic tag names and preventing control structures and content blocks in attribute names.

That's why I've parameterized the `PreventOutputInTagsAndAttributes`, to make it possible to only disable the check that you need, like this: https://github.com/casid/jte/blob/66dbec00f9be247e06a200e531b2a3ecdd2a0c08/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngine_HtmlOutputEscapingTest.java#L1419

As an alternative, you could also use `$unsafe` for these parts and stick with the default `OwaspHtmlPolicy`, like here: https://github.com/casid/jte/blob/66dbec00f9be247e06a200e531b2a3ecdd2a0c08/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngine_HtmlOutputEscapingTest.java#L1448


