### PR TITLE
Bump Kotlin from 1.8.10 to latest 1.9.10.

### DIFF
--- a/jte-kotlin/pom.xml
+++ b/jte-kotlin/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
         <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
-        <kotlin.version>1.8.10</kotlin.version>
+        <kotlin.version>1.9.10</kotlin.version>
     </properties>
 
     <dependencies>

--- a/test/jte-runtime-cp-test-gradle-kotlin-convention/build.gradle.kts
+++ b/test/jte-runtime-cp-test-gradle-kotlin-convention/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.8.10"
+    kotlin("jvm") version "1.9.10"
     id("gg.jte.gradle") version("3.0.4-SNAPSHOT")
 }
 

--- a/test/jte-runtime-cp-test-gradle-kotlin/build.gradle.kts
+++ b/test/jte-runtime-cp-test-gradle-kotlin/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.nio.file.Paths
 
 plugins {
-    kotlin("jvm") version "1.8.10"
+    kotlin("jvm") version "1.9.10"
     id("gg.jte.gradle") version("3.0.4-SNAPSHOT")
 }
 


### PR DESCRIPTION
Replacement for

- #265

Looking forward to `3.0.4` with the JTE/KTE fixes, let me know if there are any tasks I can accomplish with PRs which will speed it along.