### PR TITLE
Adds missing developmentMode configuration metadata property.

### DIFF
--- a/jte-spring-boot-starter-2/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/jte-spring-boot-starter-2/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -14,6 +14,12 @@
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {
+      "name": "gg.jte.developmentMode",
+      "type": "java.lang.Boolean",
+      "description": "You can enable developmentMode so that the jte file watcher will watch for changes in templates and recompile them.",
+      "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
+    },
+    {
       "name": "gg.jte.templateLocation",
       "type": "java.lang.String",
       "description": "You can change the location where jte expects the templates to compile",
@@ -24,7 +30,7 @@
       "type": "java.lang.String",
       "description": "You can configure the file suffix of jte templates the compiler resolves",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
-    },
+    }
   ],
   "hints": []
 }

--- a/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -14,6 +14,12 @@
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {
+      "name": "gg.jte.developmentMode",
+      "type": "java.lang.Boolean",
+      "description": "You can enable developmentMode so that the jte file watcher will watch for changes in templates and recompile them.",
+      "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
+    },
+    {
       "name": "gg.jte.templateLocation",
       "type": "java.lang.String",
       "description": "You can change the location where jte expects the templates to compile",
@@ -24,7 +30,7 @@
       "type": "java.lang.String",
       "description": "You can configure the file suffix of jte templates the compiler resolves",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
-    },
+    }
   ],
   "hints": []
 }


### PR DESCRIPTION
This fixes the issue of spring boots configuration metadata problems.

Currently I cannot run SpringBoot Tests with version 3.1.0, because of the missing property. It would be great, if you could release a bugfix release for that issue. But it is not urgent.

This property was missing in https://github.com/casid/jte/pull/251