### PR TITLE
jte-models: Add support to generate Kotlin code

### DIFF
--- a/jte-models/README.md
+++ b/jte-models/README.md
@@ -20,6 +20,11 @@ To use jte-models, set up your build script to include one of these:
                     <extensions>
                         <extension>
                             <className>gg.jte.models.generator.ModelExtension</className>
+                            <!-- optional settings to configure the target language (Java and Kotlin are supported):
+                            <settings>
+                                <language>java</language>
+                            </settings>
+                            -->
                             <!-- optional settings to include annotations on generated classes:
                             <settings>
                                 <interfaceAnnotation>@foo.bar.MyAnnotation</interfaceAnnotation>
@@ -72,11 +77,17 @@ jte {
     generate()
     binaryStaticContent = true
     jteExtension 'gg.jte.models.generator.ModelExtension'
-    // or to add annotations to generated classes:
+    // or to configure the generator
     /*
     jteExtension('gg.jte.models.generator.ModelExtension') {
+        // Target language (Java and Kotlin are supported). "Java" is the default.
+        language = 'java'
+
+        // Annotations to add to generated interfaces and classes
         interfaceAnnotation = '@foo.bar.MyAnnotation'
         implementationAnnotation = '@foo.bar.MyAnnotation'
+
+        // Patterns to include (or exclude) certain templates
         includePattern = '\.pages\..*'
         excludePattern = '\.components\..*'
     }
@@ -103,11 +114,17 @@ jte {
     generate()
     binaryStaticContent.set(true)
     jteExtension("gg.jte.models.generator.ModelExtension")
-    // or to add annotations to generated classes:
+    // or to configure the generator:
     /*
     jteExtension("gg.jte.models.generator.ModelExtension") {
+        // Target language (Java and Kotlin are supported). "Java" is the default.
+        property("language", "java")
+
+        // Annotations to add to generated interfaces and classes
         property("interfaceAnnotation", "@foo.bar.MyAnnotation")
         property("implementationAnnotation", "@foo.bar.MyAnnotation")
+
+        // Patterns to include (or exclude) certain templates
         property("includePattern", "\.pages\..*")
         property("excludePattern", '\.components\..*")
     }
@@ -124,9 +141,19 @@ Additional generated classes will include a facade interface named `gg.jte.gener
 
 `Templates` has a method for each of your templates, for example:
 
+### Java
+
 ```java
 public interface Templates {
     JteModel helloWorld(String greeting);
+}
+```
+
+### Kotlin
+
+```kotlin
+interface Templates {
+    fun helloWord(greeting: String): JteModel
 }
 ```
 

--- a/jte-models/src/main/java/gg/jte/models/generator/Language.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/Language.java
@@ -1,0 +1,5 @@
+package gg.jte.models.generator;
+
+public enum Language {
+    JAVA, KOTLIN
+}

--- a/jte-models/src/main/java/gg/jte/models/generator/Language.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/Language.java
@@ -1,5 +1,5 @@
 package gg.jte.models.generator;
 
 public enum Language {
-    JAVA, KOTLIN
+    Java, Kotlin
 }

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
@@ -18,6 +18,17 @@ public class ModelConfig {
         return map.getOrDefault("implementationAnnotation", "");
     }
 
+    public Language language() {
+        String configuredLanguage = map.getOrDefault("language", "JAVA").toUpperCase();
+        Language language = Language.JAVA;
+        try {
+            language = Language.valueOf(configuredLanguage);
+        } catch (IllegalArgumentException ex) {
+            // how to report wrong conciguration? fail or default to Java?
+        }
+        return language;
+    }
+
     public Pattern includePattern() {
         String includePattern = map.get("includePattern");
         if (includePattern == null) {

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
@@ -22,7 +22,7 @@ public class ModelConfig {
     public Language language() {
         String configuredLanguage = map.getOrDefault("language", "Java");
         try {
-            return Language.valueOf(configuredLanguage.toUpperCase());
+            return Language.valueOf(configuredLanguage);
         } catch (IllegalArgumentException ex) {
             String supportedValues = Arrays.toString(Language.values());
             throw new IllegalArgumentException(

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
@@ -20,7 +20,7 @@ public class ModelConfig {
     }
 
     public Language language() {
-        String configuredLanguage = map.getOrDefault("language", "JAVA");
+        String configuredLanguage = map.getOrDefault("language", "Java");
         try {
             return Language.valueOf(configuredLanguage.toUpperCase());
         } catch (IllegalArgumentException ex) {

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
@@ -1,5 +1,6 @@
 package gg.jte.models.generator;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -19,14 +20,16 @@ public class ModelConfig {
     }
 
     public Language language() {
-        String configuredLanguage = map.getOrDefault("language", "JAVA").toUpperCase();
-        Language language = Language.JAVA;
+        String configuredLanguage = map.getOrDefault("language", "JAVA");
         try {
-            language = Language.valueOf(configuredLanguage);
+            return Language.valueOf(configuredLanguage.toUpperCase());
         } catch (IllegalArgumentException ex) {
-            // how to report wrong conciguration? fail or default to Java?
+            String supportedValues = Arrays.toString(Language.values());
+            throw new IllegalArgumentException(
+                String.format("JTE ModelExtension 'language' property is not configured correctly (current value is '%s'). Supported values: %s", configuredLanguage, supportedValues),
+                ex
+            );
         }
-        return language;
     }
 
     public Pattern includePattern() {

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
@@ -8,7 +8,6 @@ import gg.jte.extension.api.TemplateDescription;
 
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
@@ -21,7 +21,7 @@ public class ModelExtension implements JteExtension {
 
     @Override
     public String name() {
-        return "Generate type-safe model facade for templates";
+        return "Generate type-safe model facade for templates in Java";
     }
 
     @Override
@@ -37,15 +37,17 @@ public class ModelExtension implements JteExtension {
         Pattern includePattern = modelConfig.includePattern();
         Pattern excludePattern = modelConfig.excludePattern();
 
+        Language language = modelConfig.language();
+
         var templateDescriptionsFiltered = templateDescriptions.stream() //
                 .filter(x -> includePattern == null || includePattern.matcher(x.fullyQualifiedClassName()).matches()) //
                 .filter(x -> excludePattern == null || !excludePattern.matcher(x.fullyQualifiedClassName()).matches()) //
                 .collect(Collectors.toSet());
 
         return Stream.of(
-                new ModelGenerator(engine, "interfacetemplates", "Templates", "Templates"),
-                new ModelGenerator(engine, "statictemplates", "StaticTemplates", "Templates"),
-                new ModelGenerator(engine, "dynamictemplates", "DynamicTemplates", "Templates")
+                new ModelGenerator(engine, "interfacetemplates", "Templates", "Templates", language),
+                new ModelGenerator(engine, "statictemplates", "StaticTemplates", "Templates", language),
+                new ModelGenerator(engine, "dynamictemplates", "DynamicTemplates", "Templates", language)
         ).map(g -> g.generate(config, templateDescriptionsFiltered, modelConfig))
                 .collect(Collectors.toList());
     }

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelGenerator.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelGenerator.java
@@ -23,17 +23,27 @@ public class ModelGenerator {
     private final String targetClassName;
     private final String interfaceName;
 
+    private final Language language;
+
     public ModelGenerator(TemplateEngine engine, String templateSubDirectory, String targetClassName, String interfaceName) {
+        this(engine, templateSubDirectory, targetClassName, interfaceName, Language.JAVA);
+    }
+
+    public ModelGenerator(TemplateEngine engine, String templateSubDirectory, String targetClassName, String interfaceName, Language language) {
         this.engine = engine;
         this.templateSubDirectory = templateSubDirectory;
         this.targetClassName = targetClassName;
         this.interfaceName = interfaceName;
+        this.language = language;
     }
 
     public Path generate(JteConfig config, Set<TemplateDescription> templateDescriptions, ModelConfig modelConfig) {
+        String fileExtension = language == Language.JAVA ? ".java" : ".kt";
+        String templateName = language == Language.JAVA ? "/main.jte" : "/kmain.jte";
+
         Path sourceFilePath = config.generatedSourcesRoot()
                 .resolve(config.packageName().replace('.', '/'))
-                .resolve(targetClassName + ".java");
+                .resolve(targetClassName + fileExtension);
         Iterable<String> imports = templateDescriptions.stream()
                 .flatMap(t -> t.imports().stream())
                 .collect(Collectors.toCollection(TreeSet::new));
@@ -47,7 +57,7 @@ public class ModelGenerator {
                 paramMap.put("templates", templateDescriptions);
                 paramMap.put("imports", imports);
                 paramMap.put("modelConfig", modelConfig);
-                engine.render(templateSubDirectory + "/main.jte", paramMap, new SquashBlanksOutput(new WriterOutput(w)));
+                engine.render(templateSubDirectory + templateName, paramMap, new SquashBlanksOutput(new WriterOutput(w)));
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelGenerator.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelGenerator.java
@@ -22,12 +22,7 @@ public class ModelGenerator {
     private final String templateSubDirectory;
     private final String targetClassName;
     private final String interfaceName;
-
     private final Language language;
-
-    public ModelGenerator(TemplateEngine engine, String templateSubDirectory, String targetClassName, String interfaceName) {
-        this(engine, templateSubDirectory, targetClassName, interfaceName, Language.JAVA);
-    }
 
     public ModelGenerator(TemplateEngine engine, String templateSubDirectory, String targetClassName, String interfaceName, Language language) {
         this.engine = engine;

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelGenerator.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelGenerator.java
@@ -33,8 +33,8 @@ public class ModelGenerator {
     }
 
     public Path generate(JteConfig config, Set<TemplateDescription> templateDescriptions, ModelConfig modelConfig) {
-        String fileExtension = language == Language.JAVA ? ".java" : ".kt";
-        String templateName = language == Language.JAVA ? "/main.jte" : "/kmain.jte";
+        String fileExtension = language == Language.Java ? ".java" : ".kt";
+        String templateName = language == Language.Java ? "/main.jte" : "/kmain.jte";
 
         Path sourceFilePath = config.generatedSourcesRoot()
                 .resolve(config.packageName().replace('.', '/'))

--- a/jte-models/src/main/java/gg/jte/models/generator/Util.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/Util.java
@@ -1,5 +1,6 @@
 package gg.jte.models.generator;
 
+import gg.jte.TemplateEngine;
 import gg.jte.extension.api.ParamDescription;
 import gg.jte.extension.api.TemplateDescription;
 
@@ -11,6 +12,10 @@ public class Util {
 
     public static String typedParams(TemplateDescription template) {
         return template.params().stream().map(param -> String.format("%s %s", param.type(), param.name())).collect(Collectors.joining(", "));
+    }
+
+    public static String kotlinTypedParams(TemplateDescription template) {
+        return template.params().stream().map(param -> String.format("%s: %s", param.name(), param.type())).collect(Collectors.joining(", "));
     }
 
     public static String paramNames(TemplateDescription template) {

--- a/jte-models/src/main/jte/dynamictemplates/kmain.jte
+++ b/jte-models/src/main/jte/dynamictemplates/kmain.jte
@@ -1,0 +1,26 @@
+@import gg.jte.extension.api.*
+@import gg.jte.models.generator.ModelConfig
+@import java.util.Set
+
+@param String targetClassName
+@param String interfaceName
+@param JteConfig config
+@param Set<TemplateDescription> templates
+@param Iterable<String> imports
+@param ModelConfig modelConfig
+
+@file:Suppress("ktlint")
+package ${config.packageName()}
+
+import gg.jte.TemplateEngine
+import gg.jte.models.runtime.*
+@for(String imp: imports)
+    import ${imp}
+@endfor
+
+${modelConfig.implementationAnnotation()}
+class ${targetClassName}(private val engine: TemplateEngine) : ${interfaceName} {
+    @for(TemplateDescription template: templates)
+        @template.dynamictemplates.kmethod(template = template)
+    @endfor
+}

--- a/jte-models/src/main/jte/dynamictemplates/kmethod.jte
+++ b/jte-models/src/main/jte/dynamictemplates/kmethod.jte
@@ -1,0 +1,12 @@
+@import gg.jte.extension.api.*
+@import gg.jte.models.generator.Util
+
+@param TemplateDescription template
+
+    override fun ${Util.methodName(template)}(${Util.kotlinTypedParams(template)}): JteModel {
+        val paramMap = mapOf(
+        @for(ParamDescription param: template.params())
+            "${param.name()}" to ${param.name()},@endfor
+        )
+        return DynamicJteModel(engine, "${template.name()}", paramMap);
+    }

--- a/jte-models/src/main/jte/interfacetemplates/kmain.jte
+++ b/jte-models/src/main/jte/interfacetemplates/kmain.jte
@@ -1,0 +1,24 @@
+@import gg.jte.extension.api.*
+@import gg.jte.models.generator.ModelConfig
+@import java.util.Set
+
+@param String targetClassName
+@param JteConfig config
+@param Set<TemplateDescription> templates
+@param Iterable<String> imports
+@param ModelConfig modelConfig
+
+@file:Suppress("ktlint")
+package ${config.packageName()}
+
+import gg.jte.models.runtime.*
+@for(String imp: imports)
+import ${imp}
+@endfor
+
+${modelConfig.interfaceAnnotation()}
+interface ${targetClassName} {
+    @for(TemplateDescription template: templates)
+        @template.interfacetemplates.kmethod(template = template)
+    @endfor
+}

--- a/jte-models/src/main/jte/interfacetemplates/kmethod.jte
+++ b/jte-models/src/main/jte/interfacetemplates/kmethod.jte
@@ -1,0 +1,7 @@
+@import gg.jte.extension.api.*
+@import gg.jte.models.generator.Util
+
+@param TemplateDescription template
+
+    @JteView("${template.name()}")
+    fun ${Util.methodName(template)}(${Util.kotlinTypedParams(template)}): JteModel

--- a/jte-models/src/main/jte/statictemplates/kmain.jte
+++ b/jte-models/src/main/jte/statictemplates/kmain.jte
@@ -1,0 +1,29 @@
+@import gg.jte.extension.api.*
+@import gg.jte.models.generator.ModelConfig
+@import java.util.Set
+
+@param String targetClassName
+@param String interfaceName
+@param JteConfig config
+@param Set<TemplateDescription> templates
+@param Iterable<String> imports
+@param ModelConfig modelConfig
+
+@file:Suppress("ktlint")
+package ${config.packageName()}
+
+import gg.jte.models.runtime.*
+import gg.jte.ContentType
+import gg.jte.TemplateOutput
+import gg.jte.html.HtmlInterceptor
+import gg.jte.html.HtmlTemplateOutput
+@for(String imp: imports)
+    import ${imp}
+@endfor
+
+${modelConfig.implementationAnnotation()}
+class ${targetClassName} : ${interfaceName} {
+    @for(TemplateDescription template: templates)
+        @template.statictemplates.kmethod(config = config, template = template)
+    @endfor
+}

--- a/jte-models/src/main/jte/statictemplates/kmethod.jte
+++ b/jte-models/src/main/jte/statictemplates/kmethod.jte
@@ -1,0 +1,17 @@
+@import gg.jte.ContentType
+@import gg.jte.extension.api.*
+@import gg.jte.models.generator.Util
+
+@param JteConfig config
+@param TemplateDescription template
+
+!{String outputClass = config.contentType() == ContentType.Html ? "HtmlTemplateOutput" : "TemplateOutput";}
+    override fun ${Util.methodName(template)}(${Util.kotlinTypedParams(template)}): JteModel {
+        return StaticJteModel<${outputClass}>(
+            ContentType.${config.contentType()},
+            { output, interceptor -> ${template.fullyQualifiedClassName()}.render(output, interceptor${Util.paramNames(template)}) },
+            "${template.name()}",
+            "${template.packageName()}",
+            ${template.fullyQualifiedClassName()}.JTE_LINE_INFO
+        );
+    }

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
@@ -52,9 +52,10 @@ public class TestModelConfig {
     }
 
     @Test
-    public void languageConfigurationIsCaseInsensitive() {
-        var modelConfig = new ModelConfig(Map.of("language", "jAvA"));
-        assertEquals(modelConfig.language(), Language.JAVA);
+    public void languageConfigurationIsCaseSensitive() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new ModelConfig(Map.of("language", "jAvA")).language();
+        });
     }
 
     @Test

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestModelConfig {
@@ -36,20 +35,20 @@ public class TestModelConfig {
 
     @Test
     public void languageConfigurationSupportsJava() {
-        var modelConfig = new ModelConfig(Map.of("language", "JAVA"));
-        assertEquals(modelConfig.language(), Language.JAVA);
+        var modelConfig = new ModelConfig(Map.of("language", "Java"));
+        assertEquals(modelConfig.language(), Language.Java);
     }
 
     @Test
     public void languageConfigurationDefaultsToJava() {
         var modelConfig = new ModelConfig(Map.of());
-        assertEquals(modelConfig.language(), Language.JAVA);
+        assertEquals(modelConfig.language(), Language.Java);
     }
 
     @Test
     public void languageConfigurationSupportsKotlin() {
-        var modelConfig = new ModelConfig(Map.of("language", "KOTLIN"));
-        assertEquals(modelConfig.language(), Language.KOTLIN);
+        var modelConfig = new ModelConfig(Map.of("language", "Kotlin"));
+        assertEquals(modelConfig.language(), Language.Kotlin);
     }
 
     @Test
@@ -65,7 +64,7 @@ public class TestModelConfig {
         });
 
         assertEquals(
-            "JTE ModelExtension 'language' property is not configured correctly (current value is 'Ooops'). Supported values: [JAVA, KOTLIN]",
+            "JTE ModelExtension 'language' property is not configured correctly (current value is 'Ooops'). Supported values: [Java, Kotlin]",
             exception.getMessage()
         );
     }

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
@@ -1,0 +1,72 @@
+package gg.jte.models.generator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestModelConfig {
+
+    @Test
+    public void configureInterfaceAnnotation() {
+        var modelConfig = new ModelConfig(Map.of("interfaceAnnotation", "@Deprecated"));
+        assertEquals(modelConfig.interfaceAnnotation(), "@Deprecated");
+    }
+
+    @Test
+    public void interfaceAnnotationBlankWhenConfigurationNotPresent() {
+        var modelConfig = new ModelConfig(Map.of());
+        assertEquals("", modelConfig.interfaceAnnotation());
+    }
+
+    @Test
+    public void configureImplementationAnnotation() {
+        var modelConfig = new ModelConfig(Map.of("implementationAnnotation", "@Singleton"));
+        assertEquals("@Singleton", modelConfig.implementationAnnotation());
+    }
+
+    @Test
+    public void implementationAnnotationNullWhenConfigurationNotPresent() {
+        var modelConfig = new ModelConfig(Map.of());
+        assertEquals("", modelConfig.implementationAnnotation());
+    }
+
+    @Test
+    public void languageConfigurationSupportsJava() {
+        var modelConfig = new ModelConfig(Map.of("language", "JAVA"));
+        assertEquals(modelConfig.language(), Language.JAVA);
+    }
+
+    @Test
+    public void languageConfigurationDefaultsToJava() {
+        var modelConfig = new ModelConfig(Map.of());
+        assertEquals(modelConfig.language(), Language.JAVA);
+    }
+
+    @Test
+    public void languageConfigurationSupportsKotlin() {
+        var modelConfig = new ModelConfig(Map.of("language", "KOTLIN"));
+        assertEquals(modelConfig.language(), Language.KOTLIN);
+    }
+
+    @Test
+    public void languageConfigurationIsCaseInsensitive() {
+        var modelConfig = new ModelConfig(Map.of("language", "jAvA"));
+        assertEquals(modelConfig.language(), Language.JAVA);
+    }
+
+    @Test
+    public void languageConfigurationFailsWhenLanguageIsNotSupported() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            new ModelConfig(Map.of("language", "Ooops")).language();
+        });
+
+        assertEquals(
+            "JTE ModelExtension 'language' property is not configured correctly (current value is 'Ooops'). Supported values: [JAVA, KOTLIN]",
+            exception.getMessage()
+        );
+    }
+}

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
@@ -51,7 +51,7 @@ public class TestModelExtension {
     public void simpleKotlinTest() {
         JteExtension modelExtension = new ModelExtension();
         Map<String, String> config = new HashMap<>();
-        config.put("language", Language.KOTLIN.toString());
+        config.put("language", Language.Kotlin.toString());
         modelExtension.init(config);
 
         Collection<Path> generatedPaths = generatedPaths(modelExtension);

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
@@ -1,5 +1,6 @@
 package gg.jte.models.generator;
 
+import gg.jte.ContentType;
 import gg.jte.extension.api.JteExtension;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -22,31 +25,19 @@ import static gg.jte.extension.api.mocks.MockTemplateDescription.mockTemplateDes
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestModelExtension {
-    public static final Pattern INTERFACE_SOURCE_FILE = Pattern.compile("target.generated-test-sources.test.mytemplates.Templates.java");
-    JteExtension modelExtension = new ModelExtension();
+    public static final Pattern INTERFACE_JAVA_SOURCE_FILE = Pattern.compile("target.generated-test-sources.test.mytemplates.Templates.java");
+    public static final Pattern INTERFACE_KOTLIN_SOURCE_FILE = Pattern.compile("target.generated-test-sources.test.mytemplates.Templates.kt");
+
     private static final String TEST_PACKAGE = "test.mytemplates";
 
     @Test
-    public void simpleTest() {
-        Collection<Path> generatedPaths =
-                modelExtension.generate(
-                        mockConfig()
-                                .generatedSourcesRoot(Paths.get("target/generated-test-sources"))
-                                .packageName(TEST_PACKAGE),
-                        Collections.singleton(
-                                mockTemplateDescription()
-                                        .packageName(TEST_PACKAGE)
-                                        .name("hello.jte")
-                                        .className("JtehelloGenerated")
-                                        .addParams(mockParamDescription()
-                                                .type("java.lang.String")
-                                                .name("message"))
-                        )
-                );
+    public void simpleJavaTest() {
+        JteExtension modelExtension = new ModelExtension();
+        Collection<Path> generatedPaths = generatedPaths(modelExtension);
 
         assertEquals(3, generatedPaths.size());
         Collection<String> pathStrings = generatedPaths.stream().map(Path::toString).collect(Collectors.toList());
-        assertThat(pathStrings).anyMatch(p -> INTERFACE_SOURCE_FILE.matcher(p).find());
+        assertThat(pathStrings).anyMatch(p -> INTERFACE_JAVA_SOURCE_FILE.matcher(p).find());
         generatedPaths.forEach(path -> {
             try (Stream<String> lines = Files.lines(path)) {
                 assertThat(lines).anyMatch(line -> line.matches(".*JteModel hello\\(.*"));
@@ -54,5 +45,44 @@ public class TestModelExtension {
                 throw new UncheckedIOException(e);
             }
         });
+    }
+
+    @Test
+    public void simpleKotlinTest() {
+        JteExtension modelExtension = new ModelExtension();
+        Map<String, String> config = new HashMap<>();
+        config.put("language", Language.KOTLIN.toString());
+        modelExtension.init(config);
+
+        Collection<Path> generatedPaths = generatedPaths(modelExtension);
+
+        assertEquals(3, generatedPaths.size());
+        Collection<String> pathStrings = generatedPaths.stream().map(Path::toString).collect(Collectors.toList());
+        assertThat(pathStrings).anyMatch(p -> INTERFACE_KOTLIN_SOURCE_FILE.matcher(p).find());
+        generatedPaths.forEach(path -> {
+            try (Stream<String> lines = Files.lines(path)) {
+                assertThat(lines).anyMatch(line -> line.contains("fun hello(message: java.lang.String): JteModel"));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    private Collection<Path> generatedPaths(JteExtension modelExtension) {
+        return modelExtension.generate(
+                mockConfig()
+                        .contentType(ContentType.Plain)
+                        .generatedSourcesRoot(Paths.get("target/generated-test-sources"))
+                        .packageName(TEST_PACKAGE),
+                Collections.singleton(
+                        mockTemplateDescription()
+                                .packageName(TEST_PACKAGE)
+                                .name("hello.jte")
+                                .className("JtehelloGenerated")
+                                .addParams(mockParamDescription()
+                                        .type("java.lang.String")
+                                        .name("message"))
+                )
+        );
     }
 }


### PR DESCRIPTION
## What?

This adds support to generate Kotlin code (instead of Java) when using the `jte-models` extension. There are a few inconveniences when mixing both languages (clashing names such as `List`, which are different for both, not having to import standard-lib classes in Kotlin that would break the Java generate code), and having this will solve that.

## How

Simply by providing a `language` configuration to the extension. The default is Java, so people upgrading won't have to change anything in their build files. An example:

```gradle
jte {
    generate()
    binaryStaticContent = true
    jteExtension('gg.jte.models.generator.ModelExtension') {
        language = 'kotlin'
    }
}
```

## Generate code

The generated code looks like this:

```kotlin
@file:Suppress("ktlint")
package test.mytemplates

import gg.jte.models.runtime.*

interface Templates {
    
    @JteView("hello.jte")
    fun hello(message: java.lang.String): JteModel

}
```

```kotlin

@file:Suppress("ktlint")
package test.mytemplates

import gg.jte.TemplateEngine
import gg.jte.models.runtime.*

class DynamicTemplates(private val engine: TemplateEngine) : Templates {
    
    override fun hello(message: java.lang.String): JteModel {
        val paramMap = mapOf(
        
            "message" to message,
        )
        return DynamicJteModel(engine, "hello.jte", paramMap);
    }

}
```

```kotlin

@file:Suppress("ktlint")
package test.mytemplates

import gg.jte.models.runtime.*
import gg.jte.ContentType
import gg.jte.TemplateOutput
import gg.jte.html.HtmlInterceptor
import gg.jte.html.HtmlTemplateOutput

class StaticTemplates : Templates {
    
    override fun hello(message: java.lang.String): JteModel {
        return StaticJteModel<TemplateOutput>(
            ContentType.Plain,
            { output, interceptor -> test.mytemplates.JtehelloGenerated.render(output, interceptor, message) },
            "hello.jte",
            "test.mytemplates",
            test.mytemplates.JtehelloGenerated.JTE_LINE_INFO
        );
    }

}
```
