### PR TITLE
ci: Do not run code coverage on forks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,6 +35,10 @@ jobs:
 
   coverage:
 
+    # Do not run coverage for forks since they cannot upload
+    # the results to codecov. For reference, see:
+    # https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository
+    if: github.repository == 'casid/jte'
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
## What?

Code coverage job will fail on forks since they cannot upload results to
Codecov. This adds a condition to control if the job should run or not. For
more details see GitHub Actions docs:

https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution

