### PR TITLE
docs: Use latest git tag instead of pom version

### DIFF
--- a/.github/scripts/setup-docs-dependencies.sh
+++ b/.github/scripts/setup-docs-dependencies.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install mkdocs-material
+pip install mkdocs-awesome-pages-plugin
+pip install mkdocs-pom-parser-plugin

--- a/.github/scripts/setup-docs-dependencies.sh
+++ b/.github/scripts/setup-docs-dependencies.sh
@@ -3,3 +3,4 @@
 pip install mkdocs-material
 pip install mkdocs-awesome-pages-plugin
 pip install mkdocs-pom-parser-plugin
+pip install mkdocs-latest-git-tag-plugin

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -41,11 +41,8 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      # Keep the list of installed pip packages consistent with
-      # the list in validate-docs.yml.
-      - run: pip install mkdocs-material
-      - run: pip install mkdocs-awesome-pages-plugin
-      - run: pip install mkdocs-pom-parser-plugin
+      - name: Setup MkDocs
+        run: .github/scripts/setup-docs-dependencies.sh
       - name: Create new docs version
         # `_site` is the default path expected by `actions/upload-pages-artifact` to
         # find the static assets.

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # all history for all branches and tags
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # all history for all branches and tags
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -27,11 +27,8 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      # Keep the list of installed pip packages consistent with
-      # the list in publish-docs.yml.
-      - run: pip install mkdocs-material
-      - run: pip install mkdocs-awesome-pages-plugin
-      - run: pip install mkdocs-pom-parser-plugin
+      - name: Setup MkDocs
+        run: .github/scripts/setup-docs-dependencies.sh
       - name: Build docs
         # https://www.mkdocs.org/user-guide/cli/#mkdocs-build
         # --strict cause MkDocs to abort the build on any warnings.

--- a/docs/binary-rendering.md
+++ b/docs/binary-rendering.md
@@ -25,11 +25,11 @@ Most template parts are static content, and only a few parts of a template are d
 
 This generates a binary content resource for each template at compile time. Those pre-encoded UTF-8 `#!java byte[]` arrays are loaded in memory from the resource file together with the template class. This also implies that the constant pool is released from holding template strings.
 
-To fully utilize binary templates, you must use a binary template output, like [`gg.jte.Utf8ByteOutput`](https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ POM_VERSION}}/gg.jte.runtime/gg/jte/output/Utf8ByteOutput.html). This output is heavily optimized to consume as little CPU and memory as possible when using binary templates.
+To fully utilize binary templates, you must use a binary template output, like [`gg.jte.Utf8ByteOutput`](https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ latest-git-tag }}/gg.jte.runtime/gg/jte/output/Utf8ByteOutput.html). This output is heavily optimized to consume as little CPU and memory as possible when using binary templates.
 
 !!! info
 
-    You will only see a performance increase if you use [`binaryStaticContent`](https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ POM_VERSION }}/gg.jte.runtime/gg/jte/TemplateEngine.html) with a binary output. Other outputs convert the pre-encoded `#!java byte[]` arrays back to Java Strings, defeating this optimization.
+    You will only see a performance increase if you use [`binaryStaticContent`](https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ latest-git-tag }}/gg.jte.runtime/gg/jte/TemplateEngine.html) with a binary output. Other outputs convert the pre-encoded `#!java byte[]` arrays back to Java Strings, defeating this optimization.
 
 Example usage with `HttpServletResponse`:
 

--- a/docs/hot-reloading.md
+++ b/docs/hot-reloading.md
@@ -7,13 +7,13 @@ description: How to use jte hot reloading in development mode.
 
 ## For a regular website
 
-Hot reloading is supported out of the box when using the [`gg.jte.resolve.DirectoryCodeResolver`](https://www.javadoc.io/doc/gg.jte/jte/{{ POM_VERSION }}/gg.jte/gg/jte/resolve/DirectoryCodeResolver.html) (or the [`gt.jte.resolve.ResourceCodeResolver`](https://www.javadoc.io/doc/gg.jte/jte/{{ POM_VERSION }}/gg.jte/gg/jte/resolve/ResourceCodeResolver.html) with resources located outside of JAR files). Before a template is resolved, the modification timestamp of the template file and all of its dependencies is checked. If any modification is detected, the template is recompiled, and the old one is discarded to GC.
+Hot reloading is supported out of the box when using the [`gg.jte.resolve.DirectoryCodeResolver`](https://www.javadoc.io/doc/gg.jte/jte/{{ latest-git-tag }}/gg.jte/gg/jte/resolve/DirectoryCodeResolver.html) (or the [`gt.jte.resolve.ResourceCodeResolver`](https://www.javadoc.io/doc/gg.jte/jte/{{ latest-git-tag }}/gg.jte/gg/jte/resolve/ResourceCodeResolver.html) with resources located outside of JAR files). Before a template is resolved, the modification timestamp of the template file and all of its dependencies is checked. If any modification is detected, the template is recompiled, and the old one is discarded to GC.
 
 !!! warning
 
     It makes sense to do this in your local development environment only. When running in production, for maximum performance and security, [precompiled templates](#precompiling-templates) are recommended instead.
 
-If you clone [jte repository](https://github.com/casid/jte), you can launch the [`gg.jte.benchmark.SimpleWebServer`](https://github.com/casid/jte/blob/{{ POM_VERSION }}/jte/src/test/java/gg/jte/benchmark/SimpleWebServer.java) example's main method. It will fire up a tiny webserver with one page to play with at <http://localhost:8080>.
+If you clone [jte repository](https://github.com/casid/jte), you can launch the [`gg.jte.benchmark.SimpleWebServer`](https://github.com/casid/jte/blob/{{ latest-git-tag }}/jte/src/test/java/gg/jte/benchmark/SimpleWebServer.java) example's main method. It will fire up a tiny webserver with one page to play with at <http://localhost:8080>.
 
 ## For a statically rendered website
 

--- a/docs/html-rendering.md
+++ b/docs/html-rendering.md
@@ -5,7 +5,7 @@ description: How jte safely renders HTML content.
 
 # HTML Rendering
 
-For rendering HTML documents, [`gg.jte.ContentType.Html`](https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ POM_VERSION }}/gg.jte.runtime/gg/jte/ContentType.html) is highly recommended for [security](#html-escaping) but also for convenience.
+For rendering HTML documents, [`gg.jte.ContentType.Html`](https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ latest-git-tag }}/gg.jte.runtime/gg/jte/ContentType.html) is highly recommended for [security](#html-escaping) but also for convenience.
 
 ### Smart Attributes
 
@@ -49,10 +49,10 @@ jte does not render HTML, CSS and JavaScript comments. You can use the natural c
 
 ## HTML Escaping
 
-Output escaping depends on the [`gg.jte.ContentType`](https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ POM_VERSION }}/gg.jte.runtime/gg/jte/ContentType.html) the engine is created with:
+Output escaping depends on the [`gg.jte.ContentType`](https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ latest-git-tag }}/gg.jte.runtime/gg/jte/ContentType.html) the engine is created with:
 
 - With `ContentType.Plain`, there is no output escaping.
-- With `ContentType.Html`, the [OwaspHtmlTemplateOutput](https://github.com/casid/jte/blob/{{ POM_VERSION }}/jte-runtime/src/main/java/gg/jte/html/OwaspHtmlTemplateOutput.java) is used for context sensitive output escaping.
+- With `ContentType.Html`, the [OwaspHtmlTemplateOutput](https://github.com/casid/jte/blob/{{ latest-git-tag }}/jte-runtime/src/main/java/gg/jte/html/OwaspHtmlTemplateOutput.java) is used for context sensitive output escaping.
 
 In `Html` mode, user content `${}` is automatically escaped, depending on what part of the template it is placed into:
 
@@ -129,7 +129,7 @@ In case you run a [strict content security policy](https://csp.withgoogle.com/do
 
 Then, you set it with `templateEngine.setHtmlPolicy(new MyHtmlPolicy());`.
 
-For more examples, you may want to check out the [`TemplateEngine_HtmlOutputEscapingTest`](https://github.com/casid/jte/blob/{{ POM_VERSION }}/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java).
+For more examples, you may want to check out the [`TemplateEngine_HtmlOutputEscapingTest`](https://github.com/casid/jte/blob/{{ latest-git-tag }}/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java).
 
 ### Unsafe
 
@@ -143,7 +143,7 @@ The syntax `$unsafe{}` was picked on purpose. Whenever you use it, you're riskin
 
 ### Custom output escaping
 
-It is possible to provide your own implementation of `gg.jte.html.HtmlTemplateOutput`. Maybe you want to extend the default [`gg.jte.html.OwaspHtmlTemplateOutput`](https://github.com/casid/jte/blob/{{ POM_VERSION }}/jte-runtime/src/main/java/gg/jte/html/OwaspHtmlTemplateOutput.java), or use your implementation.
+It is possible to provide your own implementation of `gg.jte.html.HtmlTemplateOutput`. Maybe you want to extend the default [`gg.jte.html.OwaspHtmlTemplateOutput`](https://github.com/casid/jte/blob/{{ latest-git-tag }}/jte-runtime/src/main/java/gg/jte/html/OwaspHtmlTemplateOutput.java), or use your implementation.
 
 Before rendering, you'd simply wrap the actual `gg.jte.TemplateOutput` you are using:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ description: jte is a secure, lightweight, and fast template engine for Java and
 
 ## Getting started
 
+{{ latest-git-tag }}
+
 jte is available on [Maven Central][maven-central]:
 
 === "Maven"
@@ -39,14 +41,14 @@ jte is available on [Maven Central][maven-central]:
     <dependency>
         <groupId>{{ POM_GROUP_ID }}</groupId>
         <artifactId>jte</artifactId>
-        <version>{{ POM_VERSION }}</version>
+        <version>{{ latest-git-tag }}</version>
     </dependency>
     ```
 
 === "Gradle"
 
     ```groovy linenums="1" title="in your build.gradle"
-    implementation("{{ POM_GROUP_ID }}:jte:{{ POM_VERSION }}")
+    implementation("{{ POM_GROUP_ID }}:jte:{{ latest-git-tag }}")
     ```
 
 No further dependencies are required! Check out the [syntax documentation](syntax.md) and have fun with jte.

--- a/docs/jsp-converter.md
+++ b/docs/jsp-converter.md
@@ -18,7 +18,7 @@ First you need to add `jte-jsp-converter` as test dependency to your project:
     <dependency>
         <groupId>gg.jte</groupId>
         <artifactId>jte-jsp-converter</artifactId>
-        <version>{{ POM_VERSION }}</version>
+        <version>{{ latest-git-tag }}</version>
         <scope>test</test>
     </dependency>
     ```
@@ -26,7 +26,7 @@ First you need to add `jte-jsp-converter` as test dependency to your project:
 === "Gradle"
 
     ```groovy linenums="1"
-    testImplementation("gg.jte:jte-jsp-converter:{{ POM_VERSION }}")
+    testImplementation("gg.jte:jte-jsp-converter:{{ latest-git-tag }}")
     ```
 
 Then, add a new class in `src/test/java` to the project that you plan to migrate to jte:

--- a/docs/jte-extension-api.md
+++ b/docs/jte-extension-api.md
@@ -23,5 +23,5 @@ The jte Maven and Gradle plugins allow configuring extensions.
 ## Examples
 
 * [jte-models](jte-models.md) module is an extension that generates typesafe facades for templates.
-* [test/jte-runtime-cp-test-models](https://github.com/casid/jte/tree/{{ POM_VERSION }}/test/jte-runtime-cp-test-models) uses the Maven plugin to apply the jte-models extension.
-* [test/jte-runtime-cp-test-models-gradle](https://github.com/casid/jte/tree/{{ POM_VERSION }}/test/jte-runtime-cp-test-models-gradle) uses the Gradle plugin to apply the jte-models extension.
+* [test/jte-runtime-cp-test-models](https://github.com/casid/jte/tree/{{ latest-git-tag }}/test/jte-runtime-cp-test-models) uses the Maven plugin to apply the jte-models extension.
+* [test/jte-runtime-cp-test-models-gradle](https://github.com/casid/jte/tree/{{ latest-git-tag }}/test/jte-runtime-cp-test-models-gradle) uses the Gradle plugin to apply the jte-models extension.

--- a/docs/spring-boot-starter-2.md
+++ b/docs/spring-boot-starter-2.md
@@ -15,20 +15,20 @@ This [starter](https://docs.spring.io/spring-boot/docs/2.7.x/reference/htmlsingl
     <dependency>
         <groupId>gg.jte</groupId>
         <artifactId>jte-spring-boot-starter-2</artifactId>
-        <version>{{ POM_VERSION }}</version>
+        <version>{{ latest-git-tag }}</version>
     </dependency>
     <dependency>
         <groupId>gg.jte</groupId>
         <artifactId>jte</artifactId>
-        <version>{{ POM_VERSION }}</version>
+        <version>{{ latest-git-tag }}</version>
     </dependency>
     ```
 
 === "Gradle"
 
     ```groovy linenums="1"
-    implementation "gg.jte:jte-spring-boot-starter-2:{{ POM_VERSION }}"
-    implementation "gg.jte:jte:{{ POM_VERSION }}"
+    implementation "gg.jte:jte-spring-boot-starter-2:{{ latest-git-tag }}"
+    implementation "gg.jte:jte:{{ latest-git-tag }}"
     ```
 
 ## Usage

--- a/docs/spring-boot-starter-3.md
+++ b/docs/spring-boot-starter-3.md
@@ -15,20 +15,20 @@ This [starter](https://docs.spring.io/spring-boot/docs/3.2.x/reference/htmlsingl
     <dependency>
         <groupId>gg.jte</groupId>
         <artifactId>jte-spring-boot-starter-3</artifactId>
-        <version>{{ POM_VERSION }}</version>
+        <version>{{ latest-git-tag }}</version>
     </dependency>
     <dependency>
         <groupId>gg.jte</groupId>
         <artifactId>jte</artifactId>
-        <version>{{ POM_VERSION }}</version>
+        <version>{{ latest-git-tag }}</version>
     </dependency>
     ```
 
 === "Gradle"
 
     ```groovy linenums="1"
-    implementation "gg.jte:jte-spring-boot-starter-3:{{ POM_VERSION }}"
-    implementation "gg.jte:jte:{{ POM_VERSION }}"
+    implementation "gg.jte:jte-spring-boot-starter-3:{{ latest-git-tag }}"
+    implementation "gg.jte:jte:{{ latest-git-tag }}"
     ```
 
 ## Usage

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ markdown_extensions:
 plugins:
   - awesome-pages
   - search
+  - latest-git-tag
   - mkdocs-pom-parser-plugin:
       path: pom.xml
 


### PR DESCRIPTION
As commented here:

https://github.com/casid/jte/pull/288#issuecomment-1772720971

The current docs use the version defined in the parent pom.xml file, which shows a snapshot version when publishing from the main branch. This adds a MkDocs plugin to make it possible to use the latest tag instead.