### PR TITLE
Fix broken links

### DIFF
--- a/.github/workflows/validate-links.yml
+++ b/.github/workflows/validate-links.yml
@@ -1,0 +1,23 @@
+name: "Validate External Links"
+
+on: [push, pull_request]
+
+jobs:
+  validate-external-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: '**/*.java **/*.md **/*.xml **/*.html
+            --verbose --no-progress
+            --exclude localhost
+            --exclude "github\.com/casid/jte/blob"
+            --exclude "@template"
+            --exclude test.com
+            --exclude maven.apache.org
+            --exclude w3.org'
+          jobSummary: true
+          format: markdown
+          fail: true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/casid/jte/workflows/Test%20all%20JDKs%20on%20all%20OSes/badge.svg)](https://github.com/casid/jte/actions)
 [![Coverage Status](https://codecov.io/gh/casid/jte/branch/main/graph/badge.svg)](https://codecov.io/gh/casid/jte)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/casid/jte/master/LICENSE)
-[![Maven Central](https://img.shields.io/maven-central/v/gg.jte/jte.svg)](http://mvnrepository.com/artifact/gg.jte/jte)
+[![Maven Central](https://img.shields.io/maven-central/v/gg.jte/jte.svg)](https://mvnrepository.com/artifact/gg.jte/jte)
 
 🚀 jte 3 is here! Check out the [release notes](https://github.com/casid/jte/releases/tag/3.0.0) for exciting new features, improved performance, and streamlined dependencies.
 
@@ -44,8 +44,7 @@ Documentation lives in the [jte website](https://jte.gg/).
 
 - [Mazebert TD (game website)](https://mazebert.com)
 - [Javalin website example with login and multiple languages](https://github.com/casid/jte-javalin-tutorial)
-- [Mitch Dennett's Blog](https://www.mitchdennett.com/)
-- [FlowCrypt Admin Panel](https://flowcrypt.com/docs/business/enterprise-admin-panel.html)
+- [FlowCrypt Admin Panel](https://flowcrypt.com/docs/technical/enterprise-admin-panel/usage/ui-overview.html)
 
 [intellij-plugin]: https://plugins.jetbrains.com/plugin/14521-jte "IntelliJ jte Plugin"
 [template-benchmark]: https://github.com/casid/template-benchmark/ "Template Benchmarks"

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 - Intuitive and easy syntax, you'll rarely need to check the [documentation](https://jte.gg/)
 - Write plain Java or Kotlin for expressions. You don't need to learn yet another expression language
-- Context-sensitive [HTML escaping](https://jte.gg/latest/html-rendering/#html-escaping) at compile time
+- Context-sensitive [HTML escaping](https://jte.gg/html-rendering/#html-escaping) at compile time
 - [IntelliJ plugin][intellij-plugin] with completion and refactoring support
 - Hot reloading of templates during development
-- Blazing fast execution ([see benchmarks](https://jte.gg/latest/#performance))
+- Blazing fast execution ([see benchmarks](https://jte.gg/#performance))
 
 ## tl;dr
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/casid/jte/workflows/Test%20all%20JDKs%20on%20all%20OSes/badge.svg)](https://github.com/casid/jte/actions)
 [![Coverage Status](https://codecov.io/gh/casid/jte/branch/main/graph/badge.svg)](https://codecov.io/gh/casid/jte)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/casid/jte/master/LICENSE)
-[![Maven Central](https://img.shields.io/maven-central/v/gg.jte/jte.svg)](https://mvnrepository.com/artifact/gg.jte/jte)
+[![Maven Central](https://img.shields.io/maven-central/v/gg.jte/jte.svg)][maven-central]
 
 🚀 jte 3 is here! Check out the [release notes](https://github.com/casid/jte/releases/tag/3.0.0) for exciting new features, improved performance, and streamlined dependencies.
 
@@ -48,4 +48,4 @@ Documentation lives in the [jte website](https://jte.gg/).
 
 [intellij-plugin]: https://plugins.jetbrains.com/plugin/14521-jte "IntelliJ jte Plugin"
 [template-benchmark]: https://github.com/casid/template-benchmark/ "Template Benchmarks"
-[maven-central]: http://mvnrepository.com/artifact/gg.jte/jte "jte in Maven Central"
+[maven-central]: https://search.maven.org/artifact/gg.jte/jte "jte in Maven Central"

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ description: jte is a secure, lightweight, and fast template engine for Java and
 [![Build Status](https://github.com/casid/jte/workflows/Test%20all%20JDKs%20on%20all%20OSes/badge.svg)](https://github.com/casid/jte/actions)
 [![Coverage Status](https://codecov.io/gh/casid/jte/branch/main/graph/badge.svg)](https://codecov.io/gh/casid/jte)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/casid/jte/master/LICENSE)
-[![Maven Central](https://img.shields.io/maven-central/v/gg.jte/jte.svg)](http://mvnrepository.com/artifact/gg.jte/jte)
+[![Maven Central](https://img.shields.io/maven-central/v/gg.jte/jte.svg)][maven-central]
 
 !!! tip "jte 3 is here!"
 
@@ -283,4 +283,4 @@ This is the same benchmark as above, but the amount of threads was set to `#!jav
 
 [intellij-plugin]: https://plugins.jetbrains.com/plugin/14521-jte "IntelliJ JTE Plugin"
 [template-benchmark]: https://github.com/casid/template-benchmark/ "Template Benchmarks"
-[maven-central]: http://mvnrepository.com/artifact/gg.jte/jte "jte in Maven Central"
+[maven-central]: https://search.maven.org/artifact/gg.jte/jte "jte in Maven Central"

--- a/docs/index.md
+++ b/docs/index.md
@@ -279,8 +279,7 @@ This is the same benchmark as above, but the amount of threads was set to `#!jav
 
 - [Mazebert TD (game website)](https://mazebert.com)
 - [Javalin website example with login and multiple languages](https://github.com/casid/jte-javalin-tutorial)
-- [Mitch Dennett's Blog](https://www.mitchdennett.com/)
-- [FlowCrypt Admin Panel](https://flowcrypt.com/docs/business/enterprise-admin-panel.html)
+- [FlowCrypt Admin Panel](https://flowcrypt.com/docs/technical/enterprise-admin-panel/usage/ui-overview.html)
 
 [intellij-plugin]: https://plugins.jetbrains.com/plugin/14521-jte "IntelliJ JTE Plugin"
 [template-benchmark]: https://github.com/casid/template-benchmark/ "Template Benchmarks"

--- a/docs/jte-extension-api.md
+++ b/docs/jte-extension-api.md
@@ -23,5 +23,5 @@ The jte Maven and Gradle plugins allow configuring extensions.
 ## Examples
 
 * [jte-models](jte-models.md) module is an extension that generates typesafe facades for templates.
-* [test/jte-runtime-cp-test-models](https://github.com/casid/jte/tree/{{ latest-git-tag }}/test/jte-runtime-cp-test-models) uses the Maven plugin to apply the jte-models extension.
-* [test/jte-runtime-cp-test-models-gradle](https://github.com/casid/jte/tree/{{ latest-git-tag }}/test/jte-runtime-cp-test-models-gradle) uses the Gradle plugin to apply the jte-models extension.
+* [test/jte-runtime-cp-test-models](https://github.com/casid/jte/blob/{{ latest-git-tag }}/test/jte-runtime-cp-test-models) uses the Maven plugin to apply the jte-models extension.
+* [test/jte-runtime-cp-test-models-gradle](https://github.com/casid/jte/blob/{{ latest-git-tag }}/test/jte-runtime-cp-test-models-gradle) uses the Gradle plugin to apply the jte-models extension.

--- a/docs/pre-compiling.md
+++ b/docs/pre-compiling.md
@@ -239,5 +239,5 @@ To use this feature, set `#!groovy jteExtension("gg.jte.nativeimage.NativeResour
 
 There's an example [Gradle test project](https://github.com/casid/jte/blob/{{ latest-git-tag }}/test/jte-runtime-cp-test-gradle-convention/build.gradle) using `native-image` compilation.
 
-[jte-maven-compiler-plugin]: https://mvnrepository.com/artifact/gg.jte/jte-maven-plugin
+[jte-maven-compiler-plugin]: https://search.maven.org/artifact/gg.jte/jte-maven-plugin
 [jte-gradle-plugin]: https://plugins.gradle.org/plugin/gg.jte.gradle

--- a/docs/pre-compiling.md
+++ b/docs/pre-compiling.md
@@ -187,7 +187,7 @@ You can use a [Maven plugin][jte-maven-compiler-plugin] to generate all template
 
     Available since jte ^^**1.6.0**^^.
 
-The [Gradle plugin](https://plugins.gradle.org/plugin/gg.jte.gradle) can generate all templates during the Gradle build. Please note that paths specified in Java must match those specified in Gradle.
+The [Gradle plugin][jte-gradle-plugin] can generate all templates during the Gradle build. Please note that paths specified in Java must match those specified in Gradle.
 
 !!! warning
 
@@ -237,7 +237,7 @@ An application jar with generated classes can be built into a native binary usin
 
 To use this feature, set `#!groovy jteExtension("gg.jte.nativeimage.NativeResourcesExtension")` in your Gradle `jte` block. (Docs for Maven TBD)
 
-There's an example [Gradle test project](https://github.com/casid/jte/blob/main/test/jte-runtime-cp-test-gradle-convention/build.gradle) using `native-image` compilation.
+There's an example [Gradle test project](https://github.com/casid/jte/blob/{{ latest-git-tag }}/test/jte-runtime-cp-test-gradle-convention/build.gradle) using `native-image` compilation.
 
-[jte-maven-compiler-plugin]: https://github.com/casid/jte-maven-compiler-plugin
+[jte-maven-compiler-plugin]: https://mvnrepository.com/artifact/gg.jte/jte-maven-plugin
 [jte-gradle-plugin]: https://plugins.gradle.org/plugin/gg.jte.gradle

--- a/jte-extension-api/README.md
+++ b/jte-extension-api/README.md
@@ -1,3 +1,3 @@
 # jte-extension-api
 
-See official docs: <https://jte.gg/latest/jte-extension-api/>.
+See official docs: <https://jte.gg/jte-extension-api/>.

--- a/jte-jsp-converter/README.md
+++ b/jte-jsp-converter/README.md
@@ -1,3 +1,3 @@
 # JSP Converter
 
-See official docs: <https://jte.gg/latest/jsp-converter/>.
+See official docs: <https://jte.gg/jsp-converter/>.

--- a/jte-models/README.md
+++ b/jte-models/README.md
@@ -1,3 +1,3 @@
 # jte-models
 
-See officials docs: <https://jte.gg/latest/jte-models/>.
+See officials docs: <https://jte.gg/jte-models/>.

--- a/jte-runtime/src/main/java/gg/jte/TemplateEngine.java
+++ b/jte-runtime/src/main/java/gg/jte/TemplateEngine.java
@@ -103,7 +103,7 @@ public final class TemplateEngine {
      * No JDK is required.
      * All templates share one class loader with each other.
      * This is recommended when running templates in production.
-     * How to <a href="https://jte.gg/latest/pre-compiling/">precompile templates</a>.
+     * How to <a href="https://jte.gg/pre-compiling/">precompile templates</a>.
      *
      * @param classDirectory where template class files are located
      * @param contentType the content type of all templates this engine manages
@@ -120,7 +120,7 @@ public final class TemplateEngine {
      * This means all template classes must be bundled in you application JAR file.
      * No JDK is required.
      * This is recommended when running templates in production.
-     * How to <a href="https://jte.gg/latest/pre-compiling/">precompile templates</a>.
+     * How to <a href="https://jte.gg/pre-compiling/">precompile templates</a>.
      *
      * @param contentType the content type of all templates this engine manages
      * @return a fresh TemplateEngine instance
@@ -136,7 +136,7 @@ public final class TemplateEngine {
      * No JDK is required.
      * All templates share one class loader with each other.
      * This is recommended when running templates in production.
-     * How to <a href="https://jte.gg/latest/pre-compiling/">precompile templates</a>.
+     * How to <a href="https://jte.gg/pre-compiling/">precompile templates</a>.
      *
      * @param classDirectory where template class files are located
      * @param contentType the content type of all templates this engine manages
@@ -154,7 +154,7 @@ public final class TemplateEngine {
      * No JDK is required.
      * All templates share one class loader with each other.
      * This is recommended when running templates in production.
-     * How to <a href="https://jte.gg/latest/pre-compiling/">precompile templates</a>.
+     * How to <a href="https://jte.gg/pre-compiling/">precompile templates</a>.
      *
      * @param classDirectory where template class files are located
      * @param contentType the content type of all templates this engine manages

--- a/jte-runtime/src/main/java/gg/jte/html/policy/PreventOutputInTagsAndAttributes.java
+++ b/jte-runtime/src/main/java/gg/jte/html/policy/PreventOutputInTagsAndAttributes.java
@@ -31,7 +31,7 @@ public class PreventOutputInTagsAndAttributes implements HtmlPolicy {
         }
 
         if (htmlAttribute.getName().contains("@if")) {
-            throw new HtmlPolicyException("Illegal HTML attribute name " + htmlAttribute.getName() + "! @if expressions in HTML attribute names are not allowed. In case you're trying to optimize the generated output, smart attributes will do just that: https://jte.gg/latest/html-rendering/#smart-attributes");
+            throw new HtmlPolicyException("Illegal HTML attribute name " + htmlAttribute.getName() + "! @if expressions in HTML attribute names are not allowed. In case you're trying to optimize the generated output, smart attributes will do just that: https://jte.gg/html-rendering/#smart-attributes");
         }
 
         if (htmlAttribute.getName().contains("@for")) {

--- a/jte-spring-boot-starter-2/README.md
+++ b/jte-spring-boot-starter-2/README.md
@@ -1,3 +1,3 @@
 # jte Spring Boot 2 Starter
 
-See official docs: <https://jte.gg/latest/spring-boot-starter-2/>.
+See official docs: <https://jte.gg/spring-boot-starter-2/>.

--- a/jte-spring-boot-starter-2/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/jte-spring-boot-starter-2/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -10,7 +10,7 @@
     {
       "name": "gg.jte.usePrecompiledTemplates",
       "type": "java.lang.Boolean",
-      "description": "You can precompile the templates for faster startup and rendering. To use this you need to include the Maven or Gradle Plugin: https://jte.gg/latest/pre-compiling/",
+      "description": "You can precompile the templates for faster startup and rendering. To use this you need to include the Maven or Gradle Plugin: https://jte.gg/pre-compiling/",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {

--- a/jte-spring-boot-starter-3/README.md
+++ b/jte-spring-boot-starter-3/README.md
@@ -1,3 +1,3 @@
 # jte Spring Boot 3 Starter
 
-See official docs: <https://jte.gg/latest/spring-boot-starter-3/>.
+See official docs: <https://jte.gg/spring-boot-starter-3/>.

--- a/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -10,7 +10,7 @@
     {
       "name": "gg.jte.usePrecompiledTemplates",
       "type": "java.lang.Boolean",
-      "description": "You can precompile the templates for faster startup and rendering. To use this you need to include the Maven or Gradle Plugin: https://jte.gg/latest/pre-compiling/",
+      "description": "You can precompile the templates for faster startup and rendering. To use this you need to include the Maven or Gradle Plugin: https://jte.gg/pre-compiling/",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {

--- a/jte/src/main/java/gg/jte/compiler/ClassUtils.java
+++ b/jte/src/main/java/gg/jte/compiler/ClassUtils.java
@@ -45,7 +45,7 @@ public final class ClassUtils {
                         throw new TemplateException("Failed to append classpath for " + url, e);
                     }
                 } else if ("jar".equalsIgnoreCase(protocol)) {
-                    throw new TemplateException("For self contained applications jte templates must be precompiled. See https://jte.gg/latest/pre-compiling/#using-the-application-class-loader for more information.");
+                    throw new TemplateException("For self contained applications jte templates must be precompiled. See https://jte.gg/pre-compiling/#using-the-application-class-loader for more information.");
                 }
             }
         }

--- a/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
@@ -1183,7 +1183,7 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
         Throwable throwable = catchThrowable(() -> templateEngine.render("template.jte", true, output));
 
-        assertThat(throwable).hasMessage("Failed to compile template.jte, error at line 2: Illegal HTML attribute name @if(disabled)disabled! @if expressions in HTML attribute names are not allowed. In case you're trying to optimize the generated output, smart attributes will do just that: https://jte.gg/latest/html-rendering/#smart-attributes");
+        assertThat(throwable).hasMessage("Failed to compile template.jte, error at line 2: Illegal HTML attribute name @if(disabled)disabled! @if expressions in HTML attribute names are not allowed. In case you're trying to optimize the generated output, smart attributes will do just that: https://jte.gg/html-rendering/#smart-attributes");
     }
 
     @Test

--- a/jte/src/test/java/gg/jte/compiler/ClassUtilsTest.java
+++ b/jte/src/test/java/gg/jte/compiler/ClassUtilsTest.java
@@ -17,6 +17,6 @@ class ClassUtilsTest {
         Throwable throwable = catchThrowable(() -> ClassUtils.resolveClasspathFromClassLoader(classLoader, p -> {
         }));
 
-        assertThat(throwable).isInstanceOf(TemplateException.class).hasMessageContaining("https://jte.gg/latest/pre-compiling/#using-the-application-class-loader");
+        assertThat(throwable).isInstanceOf(TemplateException.class).hasMessageContaining("https://jte.gg/pre-compiling/#using-the-application-class-loader");
     }
 }


### PR DESCRIPTION
## What?

At some point during #288, I replaced old links, adding a `/latest/` (since the docs were supposed to be versioned). This fixes those broken links and adds a new workflow to check links across the project. A few other broken links were fixed during the process.

For reference, it uses https://github.com/lycheeverse/lychee.