### PR TITLE
Make Gradle tasks cacheable

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,8 +35,7 @@ jobs:
         if: contains(matrix.os, 'win') == false
         run: chmod +x ./mvnw
       - name: Build with Maven
-        # `-DskipTests=true` since they run on `coverage` job.
-        run: ./mvnw install --file pom.xml --batch-mode -DskipTests=true
+        run: ./mvnw install --file pom.xml --batch-mode
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - name: Build Gradle Plugin

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build Gradle Plugin
         run: cd jte-gradle-plugin && ./gradlew publishToMavenLocal
       - name: Run all the Gradle Plugin tests
-        run: cd test/gradle-test-wrapper && ./gradlew check
+        run: cd test/gradle-test-wrapper && ./gradlew --info check
 
 
   coverage:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,8 @@ jobs:
         if: contains(matrix.os, 'win') == false
         run: chmod +x ./mvnw
       - name: Build with Maven
-        run: ./mvnw install --file pom.xml --batch-mode
+        # `-DskipTests=true` since they run on `coverage` job.
+        run: ./mvnw install --file pom.xml --batch-mode -DskipTests=true
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - name: Build Gradle Plugin

--- a/jte-gradle-plugin/build.gradle
+++ b/jte-gradle-plugin/build.gradle
@@ -6,8 +6,8 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
 }
 
 dependencies {

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/GenerateJteTask.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/GenerateJteTask.java
@@ -1,6 +1,7 @@
 package gg.jte.gradle;
 
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
@@ -10,6 +11,7 @@ import org.gradle.workers.WorkerExecutor;
 import javax.inject.Inject;
 import java.nio.file.Path;
 
+@CacheableTask
 public abstract class GenerateJteTask extends JteTaskBase {
 
     private final WorkerExecutor workerExecutor;

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteTaskBase.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/JteTaskBase.java
@@ -2,13 +2,13 @@ package gg.jte.gradle;
 
 import gg.jte.ContentType;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 
-import java.io.File;
 import java.nio.file.Path;
 
 public abstract class JteTaskBase extends DefaultTask {
@@ -30,6 +30,7 @@ public abstract class JteTaskBase extends DefaultTask {
     }
 
     @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     public Path getSourceDirectory() {
         return extension.getSourceDirectory().get();
     }

--- a/jte-gradle-plugin/src/main/java/gg/jte/gradle/PrecompileJteTask.java
+++ b/jte-gradle-plugin/src/main/java/gg/jte/gradle/PrecompileJteTask.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+@CacheableTask
 public class PrecompileJteTask extends JteTaskBase {
 
     @Inject
@@ -27,6 +28,7 @@ public class PrecompileJteTask extends JteTaskBase {
     }
 
     @InputFiles
+    @CompileClasspath
     public FileCollection getCompilePath() {
         return extension.getCompilePath();
     }

--- a/test/gradle-test-wrapper/build.gradle
+++ b/test/gradle-test-wrapper/build.gradle
@@ -1,8 +1,10 @@
 plugins {
     id('java')
+    id("com.adarshr.test-logger") version "4.0.0"
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
@@ -15,4 +17,8 @@ dependencies {
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
     systemProperty("gradle.matrix.versions", System.getProperty("gradle.matrix.versions", "DEFAULT"))
+}
+
+testlogger {
+    theme 'standard'
 }

--- a/test/gradle-test-wrapper/build.gradle
+++ b/test/gradle-test-wrapper/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id('java')
-    id("com.adarshr.test-logger") version "4.0.0"
 }
 
 repositories {
@@ -17,8 +16,4 @@ dependencies {
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
     systemProperty("gradle.matrix.versions", System.getProperty("gradle.matrix.versions", "DEFAULT"))
-}
-
-testlogger {
-    theme 'standard'
 }

--- a/test/gradle-test-wrapper/src/test/java/gg/jte/GradleMatrixTest.java
+++ b/test/gradle-test-wrapper/src/test/java/gg/jte/GradleMatrixTest.java
@@ -125,6 +125,7 @@ public class GradleMatrixTest {
     }
 
     private void deleteDir(Path directoryToDelete) throws IOException {
+        if (Files.notExists(directoryToDelete)) return;
         Files.walkFileTree(directoryToDelete, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {

--- a/test/gradle-test-wrapper/src/test/java/gg/jte/GradleMatrixTest.java
+++ b/test/gradle-test-wrapper/src/test/java/gg/jte/GradleMatrixTest.java
@@ -1,6 +1,7 @@
 package gg.jte;
 
 import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Assertions;
@@ -9,9 +10,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -23,7 +27,6 @@ public class GradleMatrixTest {
     /**
      * Use system property "gradle.matrix.versions" to test multiple versions. Note this may result in downloading those
      * versions if they are not already present.
-     * @return
      */
     private static List<String> getTestGradleVersions() {
         String versionProperty = System.getProperty("gradle.matrix.versions", DEFAULT);
@@ -31,6 +34,7 @@ public class GradleMatrixTest {
     }
 
     public static final String TASK_NAME = ":check";
+
     public static Stream<Arguments> runGradleBuild() throws IOException {
         return Files.find(Paths.get(".."), 2, (p, attr) -> p.getFileName().toString().startsWith("settings.gradle"))
                 .map(Path::getParent)
@@ -40,18 +44,99 @@ public class GradleMatrixTest {
 
     @ParameterizedTest
     @MethodSource
-    public void runGradleBuild(Path projectDir, String gradleVersion) {
+    public void runGradleBuild(Path projectDir, String gradleVersion) throws IOException {
+        // Clean the configuration cache. Makes it easier to run the tests locally
+        // multiple times in a predictable way. For reference, see:
+        // https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:usage:invalidate
+        deleteDir(projectDir.resolve(".gradle/configuration-cache"));
+
+        // Then run the task
+        BuildResult result = runner(projectDir, gradleVersion)
+                .withArguments("--configuration-cache", TASK_NAME)
+                .build();
+
+        // Check task was successful
+        BuildTask task = result.task(TASK_NAME);
+        Assertions.assertNotNull(task, "Build result must have a task " + TASK_NAME);
+        Assertions.assertNotEquals(
+            TaskOutcome.FAILED,
+            task.getOutcome(),
+            String.format("Build failed in %s with Gradle Version %s", projectDir, gradleVersion)
+        );
+    }
+
+    public static Stream<Arguments> checkBuildCache() {
+        return Stream
+                .of(Paths.get("../jte-runtime-cp-test-models-gradle"), Paths.get("../jte-runtime-test-gradle-convention"))
+                .flatMap(p -> GRADLE_VERSIONS.stream().map(v -> Arguments.arguments(p, v)));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void checkBuildCache(Path projectDir, String gradleVersion) throws IOException {
+        // Populates the cache
+        runner(projectDir, gradleVersion)
+                .withArguments("--build-cache", TASK_NAME)
+                .build();
+
+        // Clean the build directory
+        deleteDir(projectDir.resolve("build"));
+
+        // A second run must result in build-cache
+        BuildResult result = runner(projectDir, gradleVersion)
+                .withArguments("--build-cache", TASK_NAME)
+                .withDebug(true)
+                .build();
+
+        BuildTask mainTask = result.task(TASK_NAME);
+        Assertions.assertNotNull(mainTask, String.format("A task named %s must be part of the build result", TASK_NAME));
+        Assertions.assertNotEquals(
+            TaskOutcome.FAILED,
+            mainTask.getOutcome(),
+            String.format("Build failed in %s with Gradle Version %s", projectDir, gradleVersion)
+        );
+
+        // Check the outcome for only these tasks since we want to test if they
+        // populate the cache properly.
+        List<BuildTask> tasks = Stream.of(":generateJte", ":precompileJte")
+                .map(result::task)
+                // When generate is executed, precompile is skipped, and vice versa, then we filter out the
+                // skipped one here.
+                .filter(task -> task != null && task.getOutcome() != TaskOutcome.SKIPPED)
+                .toList();
+
+        Assertions.assertFalse(tasks.isEmpty(), "At least one of :generateJte or :precompileJte tasks should be present");
+        tasks.forEach(task -> Assertions.assertEquals(
+                TaskOutcome.FROM_CACHE,
+                task.getOutcome(),
+                String.format("Expected outcome for task %s was %s, but got %s. Build output: \n %s", task.getPath(), TaskOutcome.FROM_CACHE, task.getOutcome(), result.getOutput())
+        ));
+    }
+
+    private GradleRunner runner(Path projectDir, String gradleVersion) {
         GradleRunner runner = GradleRunner.create()
                 .withProjectDir(projectDir.toFile())
-                .withTestKitDir(Paths.get("build").resolve(projectDir.getFileName()).toAbsolutePath().toFile())
-                .withArguments("--configuration-cache", TASK_NAME);
+                .withTestKitDir(Paths.get("build").resolve(projectDir.getFileName()).toAbsolutePath().toFile());
 
         if (!DEFAULT.equals(gradleVersion)) {
             runner = runner.withGradleVersion(gradleVersion);
         }
+        return runner;
+    }
 
-        BuildResult result = runner.build();
+    private void deleteDir(Path directoryToDelete) throws IOException {
+        Files.walkFileTree(directoryToDelete, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
 
-        Assertions.assertNotEquals(TaskOutcome.FAILED, result.task(TASK_NAME).getOutcome(), String.format("Build failed in %s with Gradle Version %s", projectDir, gradleVersion));
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 }

--- a/test/jte-runtime-cp-test-models-gradle/settings.gradle
+++ b/test/jte-runtime-cp-test-models-gradle/settings.gradle
@@ -5,3 +5,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+buildCache {
+    local {
+        directory "${System.getProperty("test.build.cache.dir")}"
+    }
+}

--- a/test/jte-runtime-test-gradle-convention/settings.gradle
+++ b/test/jte-runtime-test-gradle-convention/settings.gradle
@@ -4,3 +4,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+buildCache {
+    local {
+        directory "${System.getProperty("test.build.cache.dir")}"
+    }
+}


### PR DESCRIPTION
## What?

Gradle has a build cache that can be used to speed up the build process. From [Gradle docs](https://docs.gradle.org/current/userguide/build_cache.html):

> The Gradle build cache is a cache mechanism that aims to save time by reusing outputs produced by other builds. The build cache works by storing (locally or remotely) build outputs and allowing builds to fetch these outputs from the cache when it is determined that inputs have not changed, avoiding the expensive work of regenerating them.

I noticed that the build cache for the `compileKotlin` task was not working when using jte's `generate` or `precompile`, because the inputs generated by those tasks were not cached. Therefore, the generated code would be considered new input for `compileKotlin`, meaning the task cannot use the build cache. I suspect the same applies to `compileJava`, but I didn't check.

## Local validation

Comparison when running the `compileKotlin` task with and without `-Dorg.gradle.caching=true`.

### Before

Running with `--build-cache` multiple times has no effect since the cache is always stale:

```
time -h -p gradle --warning-mode=none --build-cache clean compileKotlin
> Task :cleanGenerateJte
> Task :cleanPrecompileJte UP-TO-DATE
> Task :clean
> Task :checkKotlinGradlePluginConfigurationErrors

> Task :generateJte
Extension gg.jte.models.generator.ModelExtension generated 3 files.

> Task :kspKotlin
> Task :compileKotlin

BUILD SUCCESSFUL in 6s
7 actionable tasks: 6 executed, 1 up-to-date
real 6.96
user 1.10
sys 0.16
```

### After

With no cache (`--warning-mode=none` for brevity):

```
time -h -p gradle --warning-mode=none clean compileKotlin
> Task :cleanGenerateJte
> Task :cleanPrecompileJte UP-TO-DATE
> Task :clean
> Task :checkKotlinGradlePluginConfigurationErrors

> Task :generateJte
Extension gg.jte.models.generator.ModelExtension generated 3 files.

> Task :kspKotlin
> Task :compileKotlin

BUILD SUCCESSFUL in 8s
7 actionable tasks: 6 executed, 1 up-to-date
real 9.30
user 1.17
sys 0.15
```

With a populated build-cache (notice the `FROM-CACHE`):

```
time -h -p gradle --warning-mode=none --build-cache clean compileKotlin
> Task :cleanGenerateJte
> Task :cleanPrecompileJte UP-TO-DATE
> Task :clean
> Task :checkKotlinGradlePluginConfigurationErrors
> Task :generateJte FROM-CACHE
> Task :kspKotlin FROM-CACHE
> Task :compileKotlin FROM-CACHE

BUILD SUCCESSFUL in 1s
7 actionable tasks: 3 executed, 3 from cache, 1 up-to-date
real 1.49
user 1.13
sys 0.16
```

Let's see the effect on `testClasses` after running the command above:


```
time -h -p gradle --warning-mode=none --build-cache clean testClasses
> Task :cleanGenerateJte
> Task :cleanPrecompileJte UP-TO-DATE
> Task :clean
> Task :checkKotlinGradlePluginConfigurationErrors
> Task :generateJte FROM-CACHE
> Task :kspKotlin FROM-CACHE
> Task :compileKotlin FROM-CACHE
> Task :compileJava NO-SOURCE
> Task :processResources
> Task :classes
> Task :kspTestKotlin
> Task :processTestResources
> Task :compileTestKotlin
> Task :compileTestJava NO-SOURCE
> Task :testClasses

BUILD SUCCESSFUL in 8s
11 actionable tasks: 7 executed, 3 from cache, 1 up-to-date
real 8.94
user 1.21
sys 0.18
```

And then, since the build cache was populated:

```
time -h -p gradle --warning-mode=none --build-cache clean testClasses
> Task :cleanGenerateJte
> Task :cleanPrecompileJte UP-TO-DATE
> Task :clean
> Task :checkKotlinGradlePluginConfigurationErrors
> Task :generateJte FROM-CACHE
> Task :kspKotlin FROM-CACHE
> Task :compileKotlin FROM-CACHE
> Task :compileJava NO-SOURCE
> Task :processResources
> Task :classes
> Task :kspTestKotlin FROM-CACHE
> Task :compileTestKotlin FROM-CACHE
> Task :compileTestJava NO-SOURCE
> Task :processTestResources
> Task :testClasses

BUILD SUCCESSFUL in 1s
11 actionable tasks: 5 executed, 5 from cache, 1 up-to-date
real 2.40
user 1.26
sys 0.16
```