### PR TITLE
Fix imports in Kotlin model generation

### DIFF
--- a/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
+++ b/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
@@ -48,6 +48,7 @@ public class KotlinCodeGenerator implements CodeGenerator {
     @Override
     public void onImport(String importClass) {
         writePackageIfRequired();
+        imports.add(importClass);
         kotlinCode.append("import ").append(importClass).append("\n");
     }
 


### PR DESCRIPTION
The models project generated Kotlin code that didn't have the correct imports. This happened because the imports were not being tracked as imports in the KotlinCodeGenerator, only as code.