### PR TITLE
Reformat the templates for Kotlin model code

### DIFF
--- a/jte-models/src/main/jte/dynamictemplates/kmain.jte
+++ b/jte-models/src/main/jte/dynamictemplates/kmain.jte
@@ -15,7 +15,7 @@ package ${config.packageName()}
 import gg.jte.TemplateEngine
 import gg.jte.models.runtime.*
 @for(String imp: imports)
-    import ${imp}
+import ${imp}
 @endfor
 
 ${modelConfig.implementationAnnotation()}

--- a/jte-models/src/main/jte/dynamictemplates/kmain.jte
+++ b/jte-models/src/main/jte/dynamictemplates/kmain.jte
@@ -8,7 +8,6 @@
 @param Set<TemplateDescription> templates
 @param Iterable<String> imports
 @param ModelConfig modelConfig
-
 @file:Suppress("ktlint")
 package ${config.packageName()}
 

--- a/jte-models/src/main/jte/dynamictemplates/kmethod.jte
+++ b/jte-models/src/main/jte/dynamictemplates/kmethod.jte
@@ -4,9 +4,13 @@
 @param TemplateDescription template
 
     override fun ${Util.methodName(template)}(${Util.kotlinTypedParams(template, false)}): JteModel {
-        val paramMap = mapOf<String, Any?>(
+        @if(template.params().isEmpty())
+        val paramMap = emptyMap<String, Any?>()
+        @else
+        val paramMap = buildMap<String, Any?> {
         @for(ParamDescription param: template.params())
-            "${param.name()}" to ${param.name()},@endfor
-        )
-        return DynamicJteModel(engine, "${template.name()}", paramMap);
+            put("${param.name()}", ${param.name()})@endfor
+        }
+        @endif
+        return DynamicJteModel(engine, "${template.name()}", paramMap)
     }

--- a/jte-models/src/main/jte/interfacetemplates/kmain.jte
+++ b/jte-models/src/main/jte/interfacetemplates/kmain.jte
@@ -7,7 +7,6 @@
 @param Set<TemplateDescription> templates
 @param Iterable<String> imports
 @param ModelConfig modelConfig
-
 @file:Suppress("ktlint")
 package ${config.packageName()}
 

--- a/jte-models/src/main/jte/statictemplates/kmain.jte
+++ b/jte-models/src/main/jte/statictemplates/kmain.jte
@@ -8,7 +8,6 @@
 @param Set<TemplateDescription> templates
 @param Iterable<String> imports
 @param ModelConfig modelConfig
-
 @file:Suppress("ktlint")
 package ${config.packageName()}
 

--- a/jte-models/src/main/jte/statictemplates/kmain.jte
+++ b/jte-models/src/main/jte/statictemplates/kmain.jte
@@ -14,11 +14,9 @@ package ${config.packageName()}
 
 import gg.jte.models.runtime.*
 import gg.jte.ContentType
-import gg.jte.TemplateOutput
-import gg.jte.html.HtmlInterceptor
 import gg.jte.html.HtmlTemplateOutput
 @for(String imp: imports)
-    import ${imp}
+import ${imp}
 @endfor
 
 ${modelConfig.implementationAnnotation()}

--- a/jte-models/src/main/jte/statictemplates/kmain.jte
+++ b/jte-models/src/main/jte/statictemplates/kmain.jte
@@ -13,6 +13,7 @@ package ${config.packageName()}
 
 import gg.jte.models.runtime.*
 import gg.jte.ContentType
+import gg.jte.TemplateOutput
 import gg.jte.html.HtmlTemplateOutput
 @for(String imp: imports)
 import ${imp}

--- a/jte-models/src/main/jte/statictemplates/kmethod.jte
+++ b/jte-models/src/main/jte/statictemplates/kmethod.jte
@@ -6,12 +6,10 @@
 @param TemplateDescription template
 
 !{String outputClass = config.contentType() == ContentType.Html ? "HtmlTemplateOutput" : "TemplateOutput";}
-    override fun ${Util.methodName(template)}(${Util.kotlinTypedParams(template, false)}): JteModel {
-        return StaticJteModel<${outputClass}>(
-            ContentType.${config.contentType()},
-            { output, interceptor -> ${template.fullyQualifiedClassName()}.render(output, interceptor${Util.paramNames(template)}) },
-            "${template.name()}",
-            "${template.packageName()}",
-            ${template.fullyQualifiedClassName()}.JTE_LINE_INFO
-        );
-    }
+    override fun ${Util.methodName(template)}(${Util.kotlinTypedParams(template, false)}): JteModel = StaticJteModel<${outputClass}>(
+        ContentType.${config.contentType()},
+        { output, interceptor -> ${template.className()}.render(output, interceptor${Util.paramNames(template)}) },
+        "${template.name()}",
+        "${template.packageName()}",
+        ${template.className()}.JTE_LINE_INFO
+    )

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static gg.jte.extension.api.mocks.MockConfig.mockConfig;
 import static gg.jte.extension.api.mocks.MockParamDescription.mockParamDescription;

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
@@ -231,7 +231,7 @@ public class TestModelExtension {
                 }
             ));
             var expected = Map.of(
-                "Templates.kt", """
+                "Templates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
                     package test.myktemplates
 
@@ -242,8 +242,8 @@ public class TestModelExtension {
                         @JteView("hello.kte")
                         fun hello(content: gg.jte.Content): JteModel
 
-                    }""",
-                "StaticTemplates.kt", """
+                    }"""),
+                "StaticTemplates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
                     package test.myktemplates
 
@@ -262,8 +262,8 @@ public class TestModelExtension {
                             JtehelloGenerated.JTE_LINE_INFO
                         )
 
-                    }""",
-                "DynamicTemplates.kt", """
+                    }"""),
+                "DynamicTemplates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
                     package test.myktemplates
                                          
@@ -282,7 +282,7 @@ public class TestModelExtension {
                             return DynamicJteModel(engine, "hello.kte", paramMap)
                         }
                                          
-                    }"""
+                    }""")
             );
             assertThat(actual).containsExactlyInAnyOrderEntriesOf(expected);
         }
@@ -314,7 +314,7 @@ public class TestModelExtension {
                 }
             ));
             var expected = Map.of(
-                "Templates.kt", """
+                "Templates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
                     package test.myktemplates
                                          
@@ -325,8 +325,8 @@ public class TestModelExtension {
                         @JteView("hello.kte")
                         fun hello(): JteModel
                                          
-                    }""",
-                "StaticTemplates.kt", """
+                    }"""),
+                "StaticTemplates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
                     package test.myktemplates
 
@@ -345,8 +345,8 @@ public class TestModelExtension {
                             JtehelloGenerated.JTE_LINE_INFO
                         )
 
-                    }""",
-                "DynamicTemplates.kt", """
+                    }"""),
+                "DynamicTemplates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
                     package test.myktemplates
                                     
@@ -362,9 +362,13 @@ public class TestModelExtension {
                             return DynamicJteModel(engine, "hello.kte", paramMap)
                         }
 
-                    }"""
+                    }""")
             );
             assertThat(actual).containsExactlyInAnyOrderEntriesOf(expected);
         }
+    }
+
+    private static String withSystemLineEndings(String content) {
+        return content.replaceAll("\n", System.lineSeparator());
     }
 }

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
@@ -249,6 +249,7 @@ public class TestModelExtension {
 
                     import gg.jte.models.runtime.*
                     import gg.jte.ContentType
+                    import gg.jte.TemplateOutput
                     import gg.jte.html.HtmlTemplateOutput
 
                     class StaticTemplates : Templates {
@@ -331,6 +332,7 @@ public class TestModelExtension {
 
                     import gg.jte.models.runtime.*
                     import gg.jte.ContentType
+                    import gg.jte.TemplateOutput
                     import gg.jte.html.HtmlTemplateOutput
 
                     class StaticTemplates : Templates {


### PR DESCRIPTION
- Change import statements to not have an indent. No functional change.
- Remove unused imports. These were likely copied over from the Java template, but are not needed in Kotlin.
- Dynamic methods, which generate a map, now use Kotlin's buildMap() instead of mapOf(). mapOf() produces extra garbage, as it creates a Pair for each entry, whereas buildMap() modifies the underlying map directly.
- Static methods are now defined as an expression. No functional change.
- In static methods, the template class name is no longer fully qualified, as it's provided as an import. No functional change.
- Remove semicolons - idiomatic Kotlin doesn't use them. No functional change.