### PR TITLE
Use Stream#toList() instead of collect()

### DIFF
--- a/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
@@ -48,6 +48,6 @@ public class ModelExtension implements JteExtension {
                 new ModelGenerator(engine, "statictemplates", "StaticTemplates", "Templates", language),
                 new ModelGenerator(engine, "dynamictemplates", "DynamicTemplates", "Templates", language)
         ).map(g -> g.generate(config, templateDescriptionsFiltered, modelConfig))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static gg.jte.extension.api.mocks.MockConfig.mockConfig;
 import static gg.jte.extension.api.mocks.MockParamDescription.mockParamDescription;
@@ -188,7 +187,7 @@ public class TestModelExtension {
                         DYNAMIC_SOURCE_FILE.matcher(path.toString()).find() ||
                         STATIC_SOURCE_FILE.matcher(path.toString()).find()
                     )
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertThat(implementationsPaths).isNotEmpty();
             implementationsPaths.forEach(path -> {

--- a/jte/src/main/java/gg/jte/compiler/TemplateCompiler.java
+++ b/jte/src/main/java/gg/jte/compiler/TemplateCompiler.java
@@ -81,7 +81,7 @@ public class TemplateCompiler extends TemplateLoader {
     @Override
     public List<String> generateAll() {
         LinkedHashSet<ClassDefinition> classDefinitions = generate(codeResolver.resolveAllTemplateNames(), false);
-        return classDefinitions.stream().map(ClassDefinition::getSourceFileName).collect(Collectors.toList());
+        return classDefinitions.stream().map(ClassDefinition::getSourceFileName).toList();
     }
 
     @Override
@@ -127,7 +127,7 @@ public class TemplateCompiler extends TemplateLoader {
             javaCompiler.compile(javaFiles, javaCompilerClassPath, config, classDirectory, templateByClassName);
         }
 
-        return classDefinitions.stream().map(ClassDefinition::getSourceFileName).collect(Collectors.toList());
+        return classDefinitions.stream().map(ClassDefinition::getSourceFileName).toList();
     }
 
     private List<String> getClassPath() {
@@ -205,7 +205,7 @@ public class TemplateCompiler extends TemplateLoader {
 
         List<JteExtension> generatorExtensions = config.extensionClasses.entrySet().stream()
                 .map(this::loadExtension)
-                .collect(Collectors.toList());
+                .toList();
         if (DEBUG) {
             System.out.printf("extensionClasses=%s generatorExtensions=%s%n", config.extensionClasses, generatorExtensions);
         }

--- a/jte/src/main/java/gg/jte/resolve/DirectoryCodeResolver.java
+++ b/jte/src/main/java/gg/jte/resolve/DirectoryCodeResolver.java
@@ -9,7 +9,6 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -66,7 +65,7 @@ public class DirectoryCodeResolver implements CodeResolver {
                     .filter(p -> !Files.isDirectory(p))
                     .map(p -> root.relativize(p).toString().replace('\\', '/'))
                     .filter(IoUtils::isTemplateFile)
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to resolve all templates in " + root, e);
         }

--- a/jte/src/test/java/gg/jte/migrate/MigrateV1To2Test.java
+++ b/jte/src/test/java/gg/jte/migrate/MigrateV1To2Test.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +26,7 @@ class MigrateV1To2Test {
     }
 
     private void copyTemplatesTo(Path tempDir) throws IOException {
-        List<Path> templates = Files.walk(sourceDirectory).filter(p -> p != sourceDirectory).collect(Collectors.toList());
+        List<Path> templates = Files.walk(sourceDirectory).filter(p -> p != sourceDirectory).toList();
         for (Path template : templates) {
             Files.copy(template, tempDir.resolve(template.getFileName()));
         }


### PR DESCRIPTION
toList was added in Java 16, and some streams can perform a more optimized operation compared to Collectors.toList().