### PR TITLE
Give TemplateDescriptions proper equals() and hashCode()

### DIFF
--- a/jte-extension-api-mocks/src/main/java/gg/jte/extension/api/mocks/MockTemplateDescription.java
+++ b/jte-extension-api-mocks/src/main/java/gg/jte/extension/api/mocks/MockTemplateDescription.java
@@ -93,14 +93,11 @@ public class MockTemplateDescription implements TemplateDescription {
 
         if (!Objects.equals(name, that.name)) return false;
         if (!Objects.equals(packageName, that.packageName)) return false;
-			return Objects.equals(className, that.className);
-		}
+        return Objects.equals(className, that.className);
+    }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (packageName != null ? packageName.hashCode() : 0);
-        result = 31 * result + (className != null ? className.hashCode() : 0);
-        return result;
+        return Objects.hash(name, packageName, className);
     }
 }

--- a/jte-extension-api-mocks/src/main/java/gg/jte/extension/api/mocks/MockTemplateDescription.java
+++ b/jte-extension-api-mocks/src/main/java/gg/jte/extension/api/mocks/MockTemplateDescription.java
@@ -6,6 +6,7 @@ import gg.jte.extension.api.TemplateDescription;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Mock implementation to help with testing extensions.
@@ -81,5 +82,25 @@ public class MockTemplateDescription implements TemplateDescription {
     @Override
     public List<String> imports() {
         return imports;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MockTemplateDescription that = (MockTemplateDescription) o;
+
+        if (!Objects.equals(name, that.name)) return false;
+        if (!Objects.equals(packageName, that.packageName)) return false;
+			return Objects.equals(className, that.className);
+		}
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (packageName != null ? packageName.hashCode() : 0);
+        result = 31 * result + (className != null ? className.hashCode() : 0);
+        return result;
     }
 }

--- a/jte-extension-api/src/main/java/gg/jte/extension/api/TemplateDescription.java
+++ b/jte-extension-api/src/main/java/gg/jte/extension/api/TemplateDescription.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 /**
  * An instance of this class will be given to an extension for each jte template.
+ * <p>
+ * Implementations must properly implement {@link Object#equals(Object)} and {@link Object#hashCode()}.
  */
 public interface TemplateDescription {
     String name();

--- a/jte-runtime/src/main/java/gg/jte/runtime/ClassInfo.java
+++ b/jte-runtime/src/main/java/gg/jte/runtime/ClassInfo.java
@@ -43,7 +43,7 @@ public final class ClassInfo {
         ClassInfo classInfo = (ClassInfo) o;
 
         return fullName.equals(classInfo.fullName);
-		}
+    }
 
     @Override
     public int hashCode() {

--- a/jte-runtime/src/main/java/gg/jte/runtime/ClassInfo.java
+++ b/jte-runtime/src/main/java/gg/jte/runtime/ClassInfo.java
@@ -34,4 +34,19 @@ public final class ClassInfo {
         }
         fullName = packageName + "." + className;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ClassInfo classInfo = (ClassInfo) o;
+
+        return fullName.equals(classInfo.fullName);
+		}
+
+    @Override
+    public int hashCode() {
+        return fullName.hashCode();
+    }
 }

--- a/jte-runtime/src/test/java/gg/jte/runtime/ClassInfoTest.java
+++ b/jte-runtime/src/test/java/gg/jte/runtime/ClassInfoTest.java
@@ -1,0 +1,25 @@
+package gg.jte.runtime;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClassInfoTest {
+
+    @Test
+    void equality() {
+        var a1 = new ClassInfo("Message", "my.app");
+        var a2 = new ClassInfo("Message", "my.app");
+        var b = new ClassInfo("OtherMessage", "my.app");
+        var c = new ClassInfo("Message", "my.app.package");
+
+        assertThat(a1).isEqualTo(a2);
+        assertThat(a1).hasSameHashCodeAs(a2);
+
+        assertThat(a1).isNotEqualTo(b);
+        assertThat(a1).doesNotHaveSameHashCodeAs(b);
+
+        assertThat(a1).isNotEqualTo(c);
+        assertThat(a1).doesNotHaveSameHashCodeAs(c);
+    }
+}

--- a/jte/src/main/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescription.java
+++ b/jte/src/main/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescription.java
@@ -42,5 +42,21 @@ public class ExtensionTemplateDescription implements TemplateDescription {
         return classDefinition.getImports();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
+        ExtensionTemplateDescription that = (ExtensionTemplateDescription) o;
+
+        if (!classDefinition.equals(that.classDefinition)) return false;
+        return classInfo.equals(that.classInfo);
+		}
+
+    @Override
+    public int hashCode() {
+        int result = classDefinition.hashCode();
+        result = 31 * result + classInfo.hashCode();
+        return result;
+    }
 }

--- a/jte/src/main/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescription.java
+++ b/jte/src/main/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescription.java
@@ -7,6 +7,7 @@ import gg.jte.runtime.ClassInfo;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class ExtensionTemplateDescription implements TemplateDescription {
     private final ClassDefinition classDefinition;
@@ -51,12 +52,10 @@ public class ExtensionTemplateDescription implements TemplateDescription {
 
         if (!classDefinition.equals(that.classDefinition)) return false;
         return classInfo.equals(that.classInfo);
-		}
+    }
 
     @Override
     public int hashCode() {
-        int result = classDefinition.hashCode();
-        result = 31 * result + classInfo.hashCode();
-        return result;
+        return Objects.hash(classDefinition, classInfo);
     }
 }

--- a/jte/src/test/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescriptionTest.java
+++ b/jte/src/test/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescriptionTest.java
@@ -26,6 +26,14 @@ class ExtensionTemplateDescriptionTest {
                 new ClassDefinition("OtherStub", "kt"),
                 new ClassInfo("Message", "my.app")
         );
+        var d = new ExtensionTemplateDescription(
+                null,
+                new ClassInfo("Message", "my.app")
+        );
+        var e = new ExtensionTemplateDescription(
+                new ClassDefinition("OtherStub", "kt"),
+                null
+        );
 
         assertThat(a1).isEqualTo(a2);
         assertThat(a1).hasSameHashCodeAs(a2);
@@ -35,5 +43,11 @@ class ExtensionTemplateDescriptionTest {
 
         assertThat(a1).isNotEqualTo(c);
         assertThat(a1).doesNotHaveSameHashCodeAs(c);
+
+        assertThat(a1).isNotEqualTo(d);
+        assertThat(a1).doesNotHaveSameHashCodeAs(d);
+
+        assertThat(a1).isNotEqualTo(e);
+        assertThat(a1).doesNotHaveSameHashCodeAs(e);
     }
 }

--- a/jte/src/test/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescriptionTest.java
+++ b/jte/src/test/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescriptionTest.java
@@ -1,0 +1,39 @@
+package gg.jte.compiler.extensionsupport;
+
+import gg.jte.compiler.ClassDefinition;
+import gg.jte.runtime.ClassInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExtensionTemplateDescriptionTest {
+
+    @Test
+    void equality() {
+        var a1 = new ExtensionTemplateDescription(
+                new ClassDefinition("Stub", "kt"),
+                new ClassInfo("Message", "my.app")
+        );
+        var a2 = new ExtensionTemplateDescription(
+                new ClassDefinition("Stub", "kt"),
+                new ClassInfo("Message", "my.app")
+        );
+        var b = new ExtensionTemplateDescription(
+                new ClassDefinition("Stub", "kt"),
+                new ClassInfo("OtherMessage", "my.app")
+        );
+        var c = new ExtensionTemplateDescription(
+                new ClassDefinition("OtherStub", "kt"),
+                new ClassInfo("Message", "my.app")
+        );
+
+        assertThat(a1).isEqualTo(a2);
+        assertThat(a1).hasSameHashCodeAs(a2);
+
+        assertThat(a1).isNotEqualTo(b);
+        assertThat(a1).doesNotHaveSameHashCodeAs(b);
+
+        assertThat(a1).isNotEqualTo(c);
+        assertThat(a1).doesNotHaveSameHashCodeAs(c);
+    }
+}


### PR DESCRIPTION
These types are frequently used in Sets. Accordingly, they'll be hashed, and so should have proper hashCode() and equals() implementations.

The implementations I chose were a best-effort guess as to the identity of the models. ClassInfo was particularly challenging as it has a mutable field and I found it challenging to figure out the difference between the various types of names.