### PR TITLE
Tweak docs

### DIFF
--- a/docs/binary-rendering.md
+++ b/docs/binary-rendering.md
@@ -9,21 +9,25 @@ description: How to use binary rendering for max throughput
 
     Available since jte ^^**1.7.0**^^.
 
-Most template parts are static content, and only a few parts of a template are dynamic. Encoding those static parts repeatedly on every request is wasteful if your web framework sends binary UTF-8 content to the user. jte makes it is possible to encode those static parts at compile time:
+Most template parts are static content, and only a few parts of a template are dynamic. Encoding those static parts repeatedly on every request is wasteful if your web framework sends binary UTF-8 content to the user. jte makes it is possible to encode those static parts when the template is compiled:
 
-=== "Java"
+=== "Java (Application run time)"
 
     ```java linenums="1"
     templateEngine.setBinaryStaticContent(true);
     ```
 
-=== "Kotlin"
+=== "Kotlin (Application run time)"
 
     ```kotlin linenums="1"
     templateEngine.binaryStaticContent = true
     ```
 
-This generates a binary content resource for each template at compile time. Those pre-encoded UTF-8 `#!java byte[]` arrays are loaded in memory from the resource file together with the template class. This also implies that the constant pool is released from holding template strings.
+=== "Application compile time"
+
+    Apply binary encoding when compiling your application by using [precompiled templates].
+
+This generates a binary content resource for each template. Those pre-encoded UTF-8 `#!java byte[]` arrays are loaded in memory from the resource file together with the template class. This also implies that the constant pool is released from holding template strings.
 
 To fully utilize binary templates, you must use a binary template output, like [`gg.jte.Utf8ByteOutput`](https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ latest-git-tag }}/gg.jte.runtime/gg/jte/output/Utf8ByteOutput.html). This output is heavily optimized to consume as little CPU and memory as possible when using binary templates.
 
@@ -52,7 +56,7 @@ Example usage with `HttpServletResponse`:
 === "Kotlin"
 
     ```kotlin linenums="1"
-    val output = new Utf8ByteOutput()
+    val output = Utf8ByteOutput()
     templateEngine.render(template, page, output)
 
     response.contentLength = output.contentLength
@@ -72,3 +76,5 @@ There are a few pretty cool things going on here:
 - Dynamic parts are usually small - and written very efficiently to internal chunks during rendering
 
 With binary content, you can render millions of pages per second (in case there's no DB or other external service interaction) with minimal CPU, memory and GC usage.
+
+[precompiled templates]: pre-compiling.md

--- a/docs/jte-models.md
+++ b/docs/jte-models.md
@@ -175,6 +175,6 @@ templates.helloWorld("Hi!").render(output);
 
 ### Static vs. Dynamic
 
-`StaticTemplates` is built so that it calls directly to jte generated render classes, with no reflection used. **This is good for a production build**.
+`StaticTemplates` is built so that it calls directly to jte generated render classes, with no reflection used. **This is good for a production build**. It builds on the outputs of [precompiled templates](pre-compiling.md).
 
 `DynamicTemplates` delegates to a `TemplateEngine`, so it can be set up to hot-reload templates. **This is good for development**. You will still have to rerun the build if @params of a template are changed.

--- a/docs/pre-compiling.md
+++ b/docs/pre-compiling.md
@@ -137,7 +137,7 @@ TemplateEngine templateEngine = TemplateEngine.createPrecompiled(ContentType.Htm
 
 This way, the templates are loaded from the application class loader. See [this issue](https://github.com/casid/jte/issues/62) for additional information.
 
-### Using the application class loader
+## Using the application class loader
 
 !!! info "Version note"
 
@@ -227,7 +227,7 @@ The [Gradle plugin][jte-gradle-plugin] can generate all templates during the Gra
     }
     ```
   
-### GraalVM native-image support
+## GraalVM native-image support
 
 !!! info "Version note"
 
@@ -239,5 +239,27 @@ To use this feature, set `#!groovy jteExtension("gg.jte.nativeimage.NativeResour
 
 There's an example [Gradle test project](https://github.com/casid/jte/blob/{{ latest-git-tag }}/test/jte-runtime-cp-test-gradle-convention/build.gradle) using `native-image` compilation.
 
+## Binary encoding
+Use [binary encoding] for maximum performance! To activate it with precompiled templates, modify your build file.
+
+=== "Maven"
+
+    ```xml linenums="1"
+    <plugin>
+        <artifactId>jte-maven-plugin</artifactId>
+        <configuration>
+            <binaryStaticContent>true</binaryStaticContent>
+            ...
+    ```
+
+=== "Gradle"
+
+    ```groovy linenums="1"
+    jte {
+        binaryStaticContent = true
+    }
+    ```
+
 [jte-maven-compiler-plugin]: https://search.maven.org/artifact/gg.jte/jte-maven-plugin
 [jte-gradle-plugin]: https://plugins.gradle.org/plugin/gg.jte.gradle
+[binary encoding]: binary-rendering.md


### PR DESCRIPTION
Fix some Kotlin code, correct an indent level, and provide some more info on how model code generation replaces precompiled templates.