### PR TITLE
ci: Do not cache locally published artifacts

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -56,3 +56,8 @@ jobs:
       - name: Stop Gradle Daemon
         if: ${{ always() }}
         run: cd test/jte-runtime-cp-test-gradle-convention && ./gradlew --stop
+
+      # This prevents local published artifacts from be added to GH Actions cache
+      - name: Clean local artifacts
+        if: ${{ always() }}
+        run: rm -rvf ~/.m2/repository/gg/jte/

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -63,6 +63,11 @@ jobs:
           name: failing-test-report
           path: test/gradle-test-wrapper/build/reports/tests/test/**/*
 
+      # This prevents local published artifacts from be added to GH Actions cache
+      - name: Clean local artifacts
+        if: ${{ always() }}
+        run: rm -rvf ~/.m2/repository/gg/jte/
+
 
   coverage:
     # Do not run coverage for forks since they cannot upload


### PR DESCRIPTION
## What?

These workflows publish artifacts to the local maven repository, which are then cached by GH Actions. Removing them at the end of the workflow prevents them from polluting the cache.

Related to https://github.com/casid/jte/pull/310#issuecomment-1884217056.

It would still be good to delete the existing caches before merging this, and check the effect it would have on #310. Deleting the caches is straightforward if you have GH CLI installed:

```bash
gh cache delete --all
```