### PR TITLE
kte: Fix parameter declaration for generated templates

### DIFF
--- a/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
+++ b/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
@@ -134,6 +134,7 @@ public class KotlinCodeGenerator implements CodeGenerator {
     public void onComplete() {
         kotlinCode.append("\t}\n");
 
+        // HERE
         kotlinCode.append("\t@JvmStatic fun renderMap(");
         writeTemplateOutputParam();
         kotlinCode.append(", jteHtmlInterceptor:gg.jte.html.HtmlInterceptor?");
@@ -144,13 +145,7 @@ public class KotlinCodeGenerator implements CodeGenerator {
                 continue;
             }
 
-            kotlinCode.setCurrentTemplateLine(parameter.templateLine);
-            kotlinCode.append("\t\tval ").append(parameter.name).append(" = params[\"").append(parameter.name).append("\"] as ").append(parameter.type);
-            if (parameter.defaultValue != null) {
-                kotlinCode.append("? ?: ");
-                writeCodeWithContentSupport(0, parameter.defaultValue);
-            }
-            kotlinCode.append('\n');
+            renderParameterDeclaration(parameter);
         }
         kotlinCode.append("\t\trender(jteOutput, jteHtmlInterceptor");
 
@@ -182,6 +177,29 @@ public class KotlinCodeGenerator implements CodeGenerator {
         kotlinCode.insert(fieldsMarker, fields, false);
 
         this.classInfo.lineInfo = kotlinCode.getLineInfo();
+    }
+
+    private void renderParameterDeclaration(ParamInfo parameter) {
+        var nonNullDefaultValue = parameter.defaultValue != null && !parameter.defaultValue.equals("null");
+
+        kotlinCode.setCurrentTemplateLine(parameter.templateLine);
+        kotlinCode.append("\t\tval ").append(parameter.name).append(" = params[\"").append(parameter.name).append("\"] as ");
+        if (nonNullDefaultValue) {
+            kotlinCode.append(asNullableType(parameter.type));
+            kotlinCode.append(" ?: ");
+            writeCodeWithContentSupport(0, parameter.defaultValue);
+        } else {
+            kotlinCode.append(parameter.type);
+        }
+        kotlinCode.append('\n');
+    }
+
+    private String asNullableType(String type) {
+        if (type.endsWith("?")) {
+            return type;
+        } else {
+            return type + "?";
+        }
     }
 
     private void addNameField(StringBuilder fields, String name) {

--- a/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
+++ b/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
@@ -134,7 +134,6 @@ public class KotlinCodeGenerator implements CodeGenerator {
     public void onComplete() {
         kotlinCode.append("\t}\n");
 
-        // HERE
         kotlinCode.append("\t@JvmStatic fun renderMap(");
         writeTemplateOutputParam();
         kotlinCode.append(", jteHtmlInterceptor:gg.jte.html.HtmlInterceptor?");
@@ -145,7 +144,7 @@ public class KotlinCodeGenerator implements CodeGenerator {
                 continue;
             }
 
-            renderParameterDeclaration(parameter);
+            writeParameterDeclaration(parameter);
         }
         kotlinCode.append("\t\trender(jteOutput, jteHtmlInterceptor");
 
@@ -179,7 +178,7 @@ public class KotlinCodeGenerator implements CodeGenerator {
         this.classInfo.lineInfo = kotlinCode.getLineInfo();
     }
 
-    private void renderParameterDeclaration(ParamInfo parameter) {
+    private void writeParameterDeclaration(ParamInfo parameter) {
         var nonNullDefaultValue = parameter.defaultValue != null && !parameter.defaultValue.equals("null");
 
         kotlinCode.setCurrentTemplateLine(parameter.templateLine);


### PR DESCRIPTION
## What?

Given the following template:

```html
@param name: String
@param age: Int? = null
```

The generated code for Kotlin's `renderMap` would have:

```kotlin
@JvmStatic fun renderMap(jteOutput:gg.jte.html.HtmlTemplateOutput, jteHtmlInterceptor:gg.jte.html.HtmlInterceptor?, params:Map<String, Any?>) {
	val name = params["name"] as String
	val age = params["age"] as Int?? ?: null
	render(jteOutput, jteHtmlInterceptor, name, age);
}
```

There are two issues here:

1. The double `?` in `Int??` generates a warning (`Redundant '?'`)
2. The section ` ?: null` also generates a warning (`Right operand of elvis operator (?:) is useless if it is null`).

This PR fixes both warnings.