### PR TITLE
fix-escaping-double-quotes

### DIFF
--- a/jte/src/main/java/gg/jte/compiler/TemplateParser.java
+++ b/jte/src/main/java/gg/jte/compiler/TemplateParser.java
@@ -190,7 +190,7 @@ public final class TemplateParser {
                 }
             } else if (currentChar == '"' && currentMode.isTrackStrings()) {
                 push(Mode.JavaCodeString);
-            } else if (currentChar == '"' && currentMode == Mode.JavaCodeString && (previousChar != '\\' || previousChar(2) == '\\')) {
+            } else if (currentChar == '"' && currentMode == Mode.JavaCodeString && (countBefore('\\') % 2 == 0)) {
                 pop();
             } else if (currentChar == '}' && currentMode == Mode.Code) {
                 pop();
@@ -362,6 +362,18 @@ public final class TemplateParser {
             completeParamsIfRequired();
             visitor.onComplete();
         }
+    }
+
+    private int countBefore(char c) {
+        int count = 0;
+        for (int j = i - 1; j >= 0; --j) {
+            if (templateCode.charAt(j) == c) {
+                ++count;
+            } else {
+                break;
+            }
+        }
+        return count;
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -1031,8 +1031,8 @@ public class TemplateEngineTest {
 
     @Test
     void backslashInString() {
-        givenTemplate("${\"\\\\\"}");
-        thenOutputIs("\\");
+        givenTemplate("${\"\\\\\\\"\\\\\"}");
+        thenOutputIs("\\\"\\");
     }
 
     @Test

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -1031,6 +1031,12 @@ public class TemplateEngineTest {
 
     @Test
     void backslashInString() {
+        givenTemplate("${\"\\\\\"}");
+        thenOutputIs("\\");
+    }
+
+    @Test
+    void backslashAndDoubleQuoteInString() {
         givenTemplate("${\"\\\\\\\"\\\\\"}");
         thenOutputIs("\\\"\\");
     }


### PR DESCRIPTION
Previous version fails`${"\\\"\\"}`. This fix accounts for that.