### PR TITLE
maven-plugin: fix kotlin compiler args parameter setting

### DIFF
--- a/jte-maven-plugin/src/main/java/gg/jte/maven/CompilerMojo.java
+++ b/jte-maven-plugin/src/main/java/gg/jte/maven/CompilerMojo.java
@@ -137,7 +137,7 @@ public class CompilerMojo extends AbstractMojo {
         templateEngine.setHtmlCommentsPreserved(htmlCommentsPreserved);
         templateEngine.setBinaryStaticContent(binaryStaticContent);
         templateEngine.setCompileArgs(calculateCompileArgs());
-        templateEngine.setCompileArgs(kotlinCompileArgs);
+        templateEngine.setKotlinCompileArgs(kotlinCompileArgs);
 
         int amount;
         try {

--- a/test/jte-runtime-test-kotlin/pom.xml
+++ b/test/jte-runtime-test-kotlin/pom.xml
@@ -14,7 +14,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <jacoco.version>0.8.10</jacoco.version>
-        <kotlin.version>1.4.30</kotlin.version>
+        <kotlin.version>1.9.10</kotlin.version>
     </properties>
 
     <dependencies>
@@ -96,6 +96,10 @@
                     <sourceDirectory>${basedir}/src/main/jte</sourceDirectory>
                     <targetDirectory>${basedir}/jte-classes</targetDirectory>
                     <contentType>Html</contentType>
+                    <kotlinCompileArgs>
+                        <kotlinCompileArg>-jvm-target</kotlinCompileArg>
+                        <kotlinCompileArg>${java.version}</kotlinCompileArg>
+                    </kotlinCompileArgs>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Ooops!

There is not much to describe. It was not passing the Kotlin compiler args wrongly as (Java) regular compiler args.