### PR TITLE
ci: Minor adjustments for dependabot pull requests

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -9,9 +9,8 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
   push:
-    paths-ignore:
-      - 'docs/**'
-      - 'mkdocs.yml'
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -4,14 +4,13 @@ name: Validate Gradle Wrapper
 # a workflow to validate the docs.
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
 on:
-    pull_request:
-        paths-ignore:
-            - 'docs/**'
-            - 'mkdocs.yml'
-    push:
-        paths-ignore:
-            - 'docs/**'
-            - 'mkdocs.yml'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+  push:
+    branches:
+      - main
 
 jobs:
   validation:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,9 +9,8 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
   push:
-    paths-ignore:
-      - 'docs/**'
-      - 'mkdocs.yml'
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -3,14 +3,13 @@ name: Validate docs
 # Only run workflow if the docs are changing.
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
 on:
-    pull_request:
-      paths:
-        - 'mkdocs.yml'
-        - 'docs/**'
-    push:
-      paths:
-        - 'mkdocs.yml'
-        - 'docs/**'
+  pull_request:
+    paths:
+      - 'mkdocs.yml'
+      - 'docs/**'
+  push:
+    branches:
+      - main
 
 jobs:
   validate:


### PR DESCRIPTION
## What?

Two minor changes based on the first PR (#344) opened by dependabot.

- Since it creates a branch in the repository instead of a fork, it runs the workflows twice (one for the PR and one for the push). Therefore, pushes will only run now when it is for the `main` branch.
- It should not try to upload code coverage.

