### PR TITLE
Use Java modern features/APIs

### DIFF
--- a/jte-jsp-converter/src/main/java/example/JteContext.java
+++ b/jte-jsp-converter/src/main/java/example/JteContext.java
@@ -17,14 +17,14 @@ public class JteContext {
     public static boolean isEmpty(Object obj) {
         if (obj == null) {
             return true;
-        } else if (obj instanceof String) {
-            return ((String) obj).length() == 0;
-        } else if (obj instanceof Object[]) {
-            return ((Object[]) obj).length == 0;
-        } else if (obj instanceof Collection) {
-            return ((Collection<?>) obj).isEmpty();
+        } else if (obj instanceof String string) {
+            return string.isEmpty();
+        } else if (obj instanceof Object[] objects) {
+            return objects.length == 0;
+        } else if (obj instanceof Collection<?> collection) {
+            return collection.isEmpty();
         } else {
-            return obj instanceof Map && ((Map<?, ?>) obj).isEmpty();
+            return obj instanceof Map<?, ?> m && m.isEmpty();
         }
     }
 

--- a/jte-jsp-converter/src/test/java/gg/jte/convert/jsp/JspToJteConverterTest.java
+++ b/jte-jsp-converter/src/test/java/gg/jte/convert/jsp/JspToJteConverterTest.java
@@ -155,8 +155,10 @@ class JspToJteConverterTest {
         givenUsecase("simpleTagWithNotYetConvertedTags");
         Throwable throwable = catchThrowable(() -> whenJspTagIsConverted("my/simple.tag", "tag/my/simple.jte"));
         assertThat(throwable).isInstanceOf(UnsupportedOperationException.class).hasMessage(
-              "The tag <my:simple-dependency1/> is used by this tag and not converted to jte yet. You should convert <my:simple-dependency1/> first. If this is a tag that should be always converted by hand, implement getNotConvertedTags() and add it there.\n" +
-              "The tag <my:simple-dependency2/> is used by this tag and not converted to jte yet. You should convert <my:simple-dependency2/> first. If this is a tag that should be always converted by hand, implement getNotConvertedTags() and add it there."
+              """
+              The tag <my:simple-dependency1/> is used by this tag and not converted to jte yet. You should convert <my:simple-dependency1/> first. If this is a tag that should be always converted by hand, implement getNotConvertedTags() and add it there.
+              The tag <my:simple-dependency2/> is used by this tag and not converted to jte yet. You should convert <my:simple-dependency2/> first. If this is a tag that should be always converted by hand, implement getNotConvertedTags() and add it there.\
+              """
         );
     }
 

--- a/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinClassCompiler.java
+++ b/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinClassCompiler.java
@@ -91,7 +91,7 @@ public class KotlinClassCompiler implements ClassCompiler {
                         line = location.getLine();
                     }
 
-                    errors.add(String.format("%s%n%s:%d:%d%nReason: %s", location.getLineContent(), location.getPath(),
+                    errors.add("%s%n%s:%d:%d%nReason: %s".formatted(location.getLineContent(), location.getPath(),
                             location.getLine(),
                             location.getColumn(), s));
                 } else {

--- a/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngineTest.java
+++ b/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngineTest.java
@@ -149,11 +149,13 @@ public class TemplateEngineTest {
 
     @Test
     void condition_else() {
-        givenTemplate("@if (model.x == 42)" +
-                "Bingo" +
-                "@else" +
-                "Bongo" +
-                "@endif");
+        givenTemplate("""
+                @if (model.x == 42)\
+                Bingo\
+                @else\
+                Bongo\
+                @endif\
+                """);
 
         model.x = 42;
         thenOutputIs("Bingo");
@@ -163,11 +165,13 @@ public class TemplateEngineTest {
 
     @Test
     void condition_elseif() {
-        givenTemplate("@if (model.x == 42)" +
-                "Bingo" +
-                "@elseif (model.x == 43)" +
-                "Bongo" +
-                "@endif!");
+        givenTemplate("""
+                @if (model.x == 42)\
+                Bingo\
+                @elseif (model.x == 43)\
+                Bongo\
+                @endif!\
+                """);
 
         model.x = 42;
         thenOutputIs("Bingo!");
@@ -196,64 +200,76 @@ public class TemplateEngineTest {
     @Test
     void conditionInContentBlock() {
         model.x = 0;
-        givenTemplate("x is ${@`@if (model.x > 0)" +
-                "positive!" +
-                "@elseif(model.x < 0)" +
-                "negative!" +
-                "@else" +
-                "zero!" +
-                "@endif`}");
+        givenTemplate("""
+                x is ${@`@if (model.x > 0)\
+                positive!\
+                @elseif(model.x < 0)\
+                negative!\
+                @else\
+                zero!\
+                @endif`}\
+                """);
         thenOutputIs("x is zero!");
     }
 
     @Test
     void loop() {
         model.array = new int[]{1, 2, 3};
-        givenTemplate("@for (i in model.array)" +
-                "${i}" +
-                "@endfor");
+        givenTemplate("""
+                @for (i in model.array)\
+                ${i}\
+                @endfor\
+                """);
         thenOutputIs("123");
     }
 
     @Test
     void loopWithCondition() {
         model.array = new int[]{1, 2, 3};
-        givenTemplate("@for (i in model.array)" +
-                "@if (i > 1)" +
-                "${i}" +
-                "@endif" +
-                "@endfor");
+        givenTemplate("""
+                @for (i in model.array)\
+                @if (i > 1)\
+                ${i}\
+                @endif\
+                @endfor\
+                """);
         thenOutputIs("23");
     }
 
     @Test
     void classicLoop() {
         model.array = new int[]{10, 20, 30};
-        givenTemplate("@for (i in model.array.indices)" +
-                "Index ${i} is ${model.array[i]}" +
-                "@if (i < model.array.size - 1)" +
-                "<br>" +
-                "@endif" +
-                "@endfor");
+        givenTemplate("""
+                @for (i in model.array.indices)\
+                Index ${i} is ${model.array[i]}\
+                @if (i < model.array.size - 1)\
+                <br>\
+                @endif\
+                @endfor\
+                """);
         thenOutputIs("Index 0 is 10<br>Index 1 is 20<br>Index 2 is 30");
     }
 
     @Test
     void loopWithVariable() {
         model.array = new int[]{1, 2, 3};
-        givenTemplate("@for (i in model.array)" +
-                "!{var y = i + 1}" +
-                "${y}" +
-                "@endfor");
+        givenTemplate("""
+                @for (i in model.array)\
+                !{var y = i + 1}\
+                ${y}\
+                @endfor\
+                """);
         thenOutputIs("234");
     }
 
     @Test
     void loopInContentBlock() {
         model.array = new int[]{1, 2, 3};
-        givenTemplate("${@`@for (i in model.array)" +
-                "${i}" +
-                "@endfor`}");
+        givenTemplate("""
+                ${@`@for (i in model.array)\
+                ${i}\
+                @endfor`}\
+                """);
         thenOutputIs("123");
     }
 
@@ -261,22 +277,26 @@ public class TemplateEngineTest {
     @Test
     void loopElse_empty() {
         model.array = new int[]{};
-        givenTemplate("@for (i in model.array)" +
-                "${i}" +
-                "@else" +
-                "Empty" +
-                "@endfor");
+        givenTemplate("""
+                @for (i in model.array)\
+                ${i}\
+                @else\
+                Empty\
+                @endfor\
+                """);
         thenOutputIs("Empty");
     }
 
     @Test
     void loopElse_notEmpty() {
         model.array = new int[]{1};
-        givenTemplate("@for (i in model.array)" +
-                "${i}" +
-                "@else" +
-                "Empty" +
-                "@endfor");
+        givenTemplate("""
+                @for (i in model.array)\
+                ${i}\
+                @else\
+                Empty\
+                @endfor\
+                """);
         thenOutputIs("1");
     }
 
@@ -320,11 +340,13 @@ public class TemplateEngineTest {
     @Test
     void loopElse_if() {
         model.array = new int[]{};
-        givenTemplate("@for (i in model.array)" +
-                "@if(i > 0)${i}@else@endif" +
-                "@else" +
-                "Empty" +
-                "@endfor");
+        givenTemplate("""
+                @for (i in model.array)\
+                @if(i > 0)${i}@else@endif\
+                @else\
+                Empty\
+                @endfor\
+                """);
         thenOutputIs("Empty");
     }
 
@@ -353,16 +375,18 @@ public class TemplateEngineTest {
     @Test
     void loopElse_multiple() {
         model.array = new int[]{1};
-        givenTemplate("@for (i in model.array)" +
-                "${i}" +
-                "@else" +
-                "Empty" +
-                "@endfor\n" +
-                "@for (i in model.array)" +
-                "${i}" +
-                "@else" +
-                "Empty" +
-                "@endfor");
+        givenTemplate("""
+                @for (i in model.array)\
+                ${i}\
+                @else\
+                Empty\
+                @endfor
+                @for (i in model.array)\
+                ${i}\
+                @else\
+                Empty\
+                @endfor\
+                """);
         thenOutputIs("1\n1");
     }
 
@@ -393,24 +417,29 @@ public class TemplateEngineTest {
 
     @Test
     void jsStringInterpolationInContentBlock() {
-        givenTemplate("!{var content = @`\n"
-              + "    <p>Hello World!</p>\n"
-              + "    @raw\n"
-              + "    <script>\n"
-              + "        const hello = \"Hello!\"\n"
-              + "        console.log(`${hello}`)\n"
-              + "    </script>\n"
-              + "    @endraw\n"
-              + "`}\n"
-              + "${content}");
-        thenOutputIs("\n\n"
-              + "    <p>Hello World!</p>\n"
-              + "    \n"
-              + "    <script>\n"
-              + "        const hello = \"Hello!\"\n"
-              + "        console.log(`${hello}`)\n"
-              + "    </script>\n"
-              + "    \n");
+        givenTemplate("""
+              !{var content = @`
+                  <p>Hello World!</p>
+                  @raw
+                  <script>
+                      const hello = "Hello!"
+                      console.log(`${hello}`)
+                  </script>
+                  @endraw
+              `}
+              ${content}\
+              """);
+        thenOutputIs("""
+              
+              
+                  <p>Hello World!</p>
+                 \s
+                  <script>
+                      const hello = "Hello!"
+                      console.log(`${hello}`)
+                  </script>
+                 \s
+              """);
     }
 
     @Test
@@ -447,36 +476,46 @@ public class TemplateEngineTest {
 
     @Test
     void tag() {
-        givenTag("card", "@param firstParam:String\n" +
-                "@param secondParam:Int\n" +
-                "One: ${firstParam}, two: ${secondParam}");
+        givenTag("card", """
+                @param firstParam:String
+                @param secondParam:Int
+                One: ${firstParam}, two: ${secondParam}\
+                """);
         givenTemplate("@template.tag.card(model.hello, model.x), That was a tag!");
         thenOutputIs("One: Hello, two: 42, That was a tag!");
     }
 
     @Test
     void tag_content() {
-        givenTag("card", "@param content:gg.jte.Content\n" +
-                "<span>${content}</span>");
+        givenTag("card", """
+                @param content:gg.jte.Content
+                <span>${content}</span>\
+                """);
         givenTemplate("@template.tag.card(@`<b>${model.hello}</b>`), That was a tag!");
         thenOutputIs("<span><b>Hello</b></span>, That was a tag!");
     }
 
     @Test
     void tag_content_comma() {
-        givenTag("card", "@param content:gg.jte.Content\n" +
-                "<span>${content}</span>");
+        givenTag("card", """
+                @param content:gg.jte.Content
+                <span>${content}</span>\
+                """);
         givenTemplate("@template.tag.card(@`<b>Hello, ${model.hello}</b>`), That was a tag!");
         thenOutputIs("<span><b>Hello, Hello</b></span>, That was a tag!");
     }
 
     @Test
     void tagWithGenericParam() {
-        givenTag("entry", "@param list:List<String>?\n" +
-                "${list.toString()}");
-        givenRawTemplate("@param map:Map<String, List<String>>\n" +
-                "@template.tag.entry(map[\"one\"])\n" +
-                "@template.tag.entry(map[\"two\"])\n");
+        givenTag("entry", """
+                @param list:List<String>?
+                ${list.toString()}\
+                """);
+        givenRawTemplate("""
+                @param map:Map<String, List<String>>
+                @template.tag.entry(map["one"])
+                @template.tag.entry(map["two"])
+                """);
 
         Map<String, List<String>> model = new TreeMap<>();
         model.put("one", Arrays.asList("1", "2"));
@@ -490,39 +529,49 @@ public class TemplateEngineTest {
 
     @Test
     void tagWithMethodCallForParam() {
-        givenTag("card", "@param firstParam:String\n" +
-                "@param secondParam:Int\n" +
-                "One: ${firstParam}, two: ${secondParam}");
+        givenTag("card", """
+                @param firstParam:String
+                @param secondParam:Int
+                One: ${firstParam}, two: ${secondParam}\
+                """);
         givenTemplate("@template.tag.card(model.anotherWorld, model.x), That was a tag!");
         thenOutputIs("One: Another World, two: 42, That was a tag!");
     }
 
     @Test
     void tagInTag() {
-        givenTag("divTwo", "@param amount:Int\n" +
-                "Divided by two is ${amount / 2}!");
-        givenTag("card", "@param firstParam:String\n" +
-                "@param secondParam:Int\n" +
-                "${firstParam}, @template.tag.divTwo(secondParam)");
+        givenTag("divTwo", """
+                @param amount:Int
+                Divided by two is ${amount / 2}!\
+                """);
+        givenTag("card", """
+                @param firstParam:String
+                @param secondParam:Int
+                ${firstParam}, @template.tag.divTwo(secondParam)\
+                """);
         givenTemplate("@template.tag.card (model.hello, model.x) That was a tag in a tag!");
         thenOutputIs("Hello, Divided by two is 21! That was a tag in a tag!");
     }
 
     @Test
     void sameTagReused() {
-        givenTag("divTwo", "@param amount:Int\n" +
-                "${amount / 2}!");
+        givenTag("divTwo", """
+                @param amount:Int
+                ${amount / 2}!\
+                """);
         givenTemplate("@template.tag.divTwo(model.x),@template.tag.divTwo(2 * model.x)");
         thenOutputIs("21!,42!");
     }
 
     @Test
     void tagRecursion() {
-        givenTag("recursion", "@param amount:Int\n" +
-                "${amount}" +
-                "@if (amount > 0)" +
-                "@template.tag.recursion(amount - 1)" +
-                "@endif"
+        givenTag("recursion", """
+                @param amount:Int
+                ${amount}\
+                @if (amount > 0)\
+                @template.tag.recursion(amount - 1)\
+                @endif\
+                """
         );
         givenTemplate("@template.tag.recursion(5)");
         thenOutputIs("543210");
@@ -551,40 +600,50 @@ public class TemplateEngineTest {
 
     @Test
     void tagWithNamedParam() {
-        givenTag("named", "@param one:Int\n" +
-                "@param two:Int\n" +
-                "${one}, ${two}");
+        givenTag("named", """
+                @param one:Int
+                @param two:Int
+                ${one}, ${two}\
+                """);
         givenTemplate("@template.tag.named(two = 2, one = 1)");
         thenOutputIs("1, 2");
     }
 
     @Test
     void tagWithNamedParamString() {
-        givenTag("named", "@param one:Int\n" +
-                "@param two:Int\n" +
-                "@param three:String\n" +
-                "${one}, ${two}, ${three}");
-        givenTemplate("@template.tag.named(\n" +
-                "two = 2,\n" +
-                "three = \"Hello, there ;-)\",\n" +
-                "one = 1)");
+        givenTag("named", """
+                @param one:Int
+                @param two:Int
+                @param three:String
+                ${one}, ${two}, ${three}\
+                """);
+        givenTemplate("""
+                @template.tag.named(
+                two = 2,
+                three = "Hello, there ;-)",
+                one = 1)\
+                """);
         thenOutputIs("1, 2, Hello, there ;-)");
     }
 
     @Test
     void tagWithNamedParam_ternary() {
-        givenTag("named", "@param one:Int\n" +
-                "@param two:Int\n" +
-                "${one}, ${two}");
+        givenTag("named", """
+                @param one:Int
+                @param two:Int
+                ${one}, ${two}\
+                """);
         givenTemplate("@template.tag.named(two = if(1 == 2) 1 else 0, one = 1)");
         thenOutputIs("1, 0");
     }
 
     @Test
     void tagWithDefaultParam() {
-        givenTag("named", "@param one:Int = 1\n" +
-                "@param two:Int = 2\n" +
-                "${one}, ${two}");
+        givenTag("named", """
+                @param one:Int = 1
+                @param two:Int = 2
+                ${one}, ${two}\
+                """);
         givenTemplate("@template.tag.named()");
 
         thenOutputIs("1, 2");
@@ -592,9 +651,11 @@ public class TemplateEngineTest {
 
     @Test
     void tagWithDefaultContentParam() {
-        givenTag("named", "@param one:Int = 1\n" +
-                          "@param content:gg.jte.Content = @`Some Content`\n" +
-                          "First param = ${one}, Content param = ${content}");
+        givenTag("named", """
+                          @param one:Int = 1
+                          @param content:gg.jte.Content = @`Some Content`
+                          First param = ${one}, Content param = ${content}\
+                          """);
         givenTemplate("@template.tag.named()");
 
         thenOutputIs("First param = 1, Content param = Some Content");
@@ -602,8 +663,10 @@ public class TemplateEngineTest {
 
     @Test
     void tagWithDefaultParam_generic() {
-        givenTag("named", "@param files: Map<String, ByteArray> = emptyMap()\n" +
-                "${files.size}");
+        givenTag("named", """
+                @param files: Map<String, ByteArray> = emptyMap()
+                ${files.size}\
+                """);
         givenTemplate("@template.tag.named()");
 
         thenOutputIs("0");
@@ -611,8 +674,10 @@ public class TemplateEngineTest {
 
     @Test
     void tagWithDefaultParam_generic_nullDefault() {
-        givenTag("named", "@param files: Map<String, ByteArray>? = null\n" +
-                "${files?.size}");
+        givenTag("named", """
+                @param files: Map<String, ByteArray>? = null
+                ${files?.size}\
+                """);
         givenTemplate("@template.tag.named()");
 
         thenOutputIs("");
@@ -620,8 +685,10 @@ public class TemplateEngineTest {
 
     @Test
     void tagWithDefaultParam_generic_nullDefault_withValue() {
-        givenTag("named", "@param files: Map<String, ByteArray>? = null\n" +
-                "${files?.size}");
+        givenTag("named", """
+                @param files: Map<String, ByteArray>? = null
+                ${files?.size}\
+                """);
         givenTemplate("@template.tag.named(mapOf(\"foo\" to ByteArray(1)))");
 
         thenOutputIs("1");
@@ -629,9 +696,11 @@ public class TemplateEngineTest {
 
     @Test
     void tagWithDefaultParam_firstSet() {
-        givenTag("named", "@param one:Int = 1\n" +
-                "@param two:Int = 2\n" +
-                "${one}, ${two}");
+        givenTag("named", """
+                @param one:Int = 1
+                @param two:Int = 2
+                ${one}, ${two}\
+                """);
         givenTemplate("@template.tag.named(one = 6)");
 
         thenOutputIs("6, 2");
@@ -639,9 +708,11 @@ public class TemplateEngineTest {
 
     @Test
     void tagWithDefaultParam_secondSet() {
-        givenTag("named", "@param one:Int = 1\n" +
-                "@param two:Int = 2\n" +
-                "${one}, ${two}");
+        givenTag("named", """
+                @param one:Int = 1
+                @param two:Int = 2
+                ${one}, ${two}\
+                """);
         givenTemplate("@template.tag.named(two= 5)");
 
         thenOutputIs("1, 5");
@@ -649,9 +720,11 @@ public class TemplateEngineTest {
 
     @Test
     void templateWithDefaultParam_content() {
-        givenTag("named", "@param one:gg.jte.Content = @`This is`\n" +
-                "@param two:Int = 2\n" +
-                "${one}: ${two}");
+        givenTag("named", """
+                @param one:gg.jte.Content = @`This is`
+                @param two:Int = 2
+                ${one}: ${two}\
+                """);
         givenTemplate("@template.tag.named()");
 
         thenOutputIs("This is: 2");
@@ -660,8 +733,10 @@ public class TemplateEngineTest {
     @Test
     void tagWithVarArgs1() {
         givenTag("varargs",
-                "@param vararg values:String\n" +
-                "@for(value in values)${value} @endfor");
+                """
+                @param vararg values:String
+                @for(value in values)${value} @endfor\
+                """);
         givenTemplate("@template.tag.varargs(\"Hello\")");
         thenOutputIs("Hello ");
     }
@@ -669,8 +744,10 @@ public class TemplateEngineTest {
     @Test
     void tagWithVarArgs2() {
         givenTag("varargs",
-                "@param vararg values:String\n" +
-                "@for(value in values)${value} @endfor");
+                """
+                @param vararg values:String
+                @for(value in values)${value} @endfor\
+                """);
         givenTemplate("@template.tag.varargs(\"Hello\", \"World\")");
         thenOutputIs("Hello World ");
     }
@@ -678,24 +755,31 @@ public class TemplateEngineTest {
     @Test
     void tagWithVarArgs3() {
         givenTag("localize",
-                "@param key:String\n" +
-                "@param vararg values:String\n" +
-                "${key} with @for(value in values)${value} @endfor");
+                """
+                @param key:String
+                @param vararg values:String
+                ${key} with @for(value in values)${value} @endfor\
+                """);
         givenTemplate("@template.tag.localize(key = \"test.key\", \"Hello\", \"World\")");
         thenOutputIs("test.key with Hello World ");
     }
 
     @Test
     void comment() {
-        givenTemplate("<%--This is a comment" +
-                " ${model.hello} everything in here is omitted--%>" +
-                "This is visible...");
+        givenTemplate("""
+                <%--This is a comment\
+                 ${model.hello} everything in here is omitted--%>\
+                This is visible...\
+                """);
         thenOutputIs("This is visible...");
     }
 
     @Test
     void commentBeforeImports() {
-        givenRawTemplate("<%--This is a comment--%>@import gg.jte.kotlin.TemplateEngineTest.Model\n@param model:Model\n" + "!{model.setX(12)}${model.x}");
+        givenRawTemplate("""
+                <%--This is a comment--%>@import gg.jte.kotlin.TemplateEngineTest.Model
+                @param model:Model
+                !{model.setX(12)}${model.x}""");
         thenOutputIs("12");
     }
 
@@ -731,19 +815,28 @@ public class TemplateEngineTest {
 
     @Test
     void importInCss() {
-        givenTemplate("<style type=\"text/css\" rel=\"stylesheet\" media=\"all\">\n" +
-                "    @import url(\"https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap\"); /* <--- Right here */");
-        thenOutputIs("<style type=\"text/css\" rel=\"stylesheet\" media=\"all\">\n" +
-                "    @import url(\"https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap\"); /* <--- Right here */");
+        givenTemplate("""
+                <style type="text/css" rel="stylesheet" media="all">
+                    @import url("https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap"); /* <--- Right here */\
+                """);
+        thenOutputIs("""
+                <style type="text/css" rel="stylesheet" media="all">
+                    @import url("https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap"); /* <--- Right here */\
+                """);
     }
 
     @Test
     void importInCss2() {
-        givenTemplate("<style type=\"text/css\" rel=\"stylesheet\" media=\"all\">\n" +
-                "xxx@if(model.hello != null)    @import url(\"${model.hello}\");\n@endif</style>");
-        thenOutputIs("<style type=\"text/css\" rel=\"stylesheet\" media=\"all\">\n" +
-                "xxx    @import url(\"Hello\");\n" +
-                "</style>");
+        givenTemplate("""
+                <style type="text/css" rel="stylesheet" media="all">
+                xxx@if(model.hello != null)    @import url("${model.hello}");
+                @endif</style>\
+                """);
+        thenOutputIs("""
+                <style type="text/css" rel="stylesheet" media="all">
+                xxx    @import url("Hello");
+                </style>\
+                """);
     }
 
     @Test
@@ -815,94 +908,112 @@ public class TemplateEngineTest {
 
     @Test
     void layout() {
-        givenLayout("main", "@param model:gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                "@param content:gg.jte.Content\n" +
-                "@param footer:gg.jte.Content\n" +
-                "<body>\n" +
-                "<b>Welcome to my site - you are on page ${model.x}</b>\n" +
-                "\n" +
-                "<div class=\"content\">\n" +
-                "    ${content}\n" +
-                "</div>\n" +
-                "\n" +
-                "<div class=\"footer\">\n" +
-                "    ${footer}\n" +
-                "</div>\n" +
-                "</body>");
+        givenLayout("main", """
+                @param model:gg.jte.kotlin.TemplateEngineTest.Model
+                @param content:gg.jte.Content
+                @param footer:gg.jte.Content
+                <body>
+                <b>Welcome to my site - you are on page ${model.x}</b>
+                
+                <div class="content">
+                    ${content}
+                </div>
+                
+                <div class="footer">
+                    ${footer}
+                </div>
+                </body>\
+                """);
 
-        givenTemplate("@template.layout.main(model, content = @`\n" +
-                "        ${model.hello}, enjoy this great content\n" +
-                "    `,\n" +
-                "    footer = @`\n" +
-                "        Come again!\n" +
-                "    `)");
+        givenTemplate("""
+                @template.layout.main(model, content = @`
+                        ${model.hello}, enjoy this great content
+                    `,
+                    footer = @`
+                        Come again!
+                    `)\
+                """);
 
         thenOutputIs(
-                "<body>\n" +
-                "<b>Welcome to my site - you are on page 42</b>\n" +
-                "\n" +
-                "<div class=\"content\">\n" +
-                "    \n" +
-                "        Hello, enjoy this great content\n" +
-                "    \n" +
-                "</div>\n" +
-                "\n" +
-                "<div class=\"footer\">\n" +
-                "    \n" +
-                "        Come again!\n" +
-                "    \n" +
-                "</div>\n" +
-                "</body>");
+                """
+                <body>
+                <b>Welcome to my site - you are on page 42</b>
+                
+                <div class="content">
+                   \s
+                        Hello, enjoy this great content
+                   \s
+                </div>
+                
+                <div class="footer">
+                   \s
+                        Come again!
+                   \s
+                </div>
+                </body>\
+                """);
     }
 
     @Test
     void nestedLayouts() {
         givenLayout("main",
-                "@param header:gg.jte.Content? = null\n" +
-                "@param content:gg.jte.Content\n" +
-                "@param footer:gg.jte.Content? = null\n" +
-                "@if(header != null)<header>${header}</header>@endif" +
-                "<content>${content}</content>" +
-                "@if(footer != null)<footer>${footer}</footer>@endif");
+                """
+                @param header:gg.jte.Content? = null
+                @param content:gg.jte.Content
+                @param footer:gg.jte.Content? = null
+                @if(header != null)<header>${header}</header>@endif\
+                <content>${content}</content>\
+                @if(footer != null)<footer>${footer}</footer>@endif\
+                """);
         givenLayout("mainExtended",
-                "@param header:gg.jte.Content? = null\n" +
-                "@param contentPrefix:gg.jte.Content? = null\n" +
-                "@param content:gg.jte.Content\n" +
-                "@param contentSuffix:gg.jte.Content? = null\n" +
-                "@param footer:gg.jte.Content? = null\n" +
-                "@template.layout.main(header = header, content = @`" +
-                "@if(contentPrefix != null)${contentPrefix}@endif" +
-                "<b>${content}</b>" +
-                "@if(contentSuffix != null)${contentSuffix}@endif" +
-                "`, footer = footer)");
-        givenTemplate("@template.layout.mainExtended(" +
-                "header = @`" +
-                "this is the header" +
-                "`," +
-                "contentPrefix = @`" +
-                "<content-prefix>" +
-                "`," +
-                "content = @`" +
-                "this is the content" +
-                "`, " +
-                "contentSuffix=@`" +
-                "<content-suffix>" +
-                "`)");
+                """
+                @param header:gg.jte.Content? = null
+                @param contentPrefix:gg.jte.Content? = null
+                @param content:gg.jte.Content
+                @param contentSuffix:gg.jte.Content? = null
+                @param footer:gg.jte.Content? = null
+                @template.layout.main(header = header, content = @`\
+                @if(contentPrefix != null)${contentPrefix}@endif\
+                <b>${content}</b>\
+                @if(contentSuffix != null)${contentSuffix}@endif\
+                `, footer = footer)\
+                """);
+        givenTemplate("""
+                @template.layout.mainExtended(\
+                header = @`\
+                this is the header\
+                `,\
+                contentPrefix = @`\
+                <content-prefix>\
+                `,\
+                content = @`\
+                this is the content\
+                `, \
+                contentSuffix=@`\
+                <content-suffix>\
+                `)\
+                """);
 
-        thenOutputIs("<header>this is the header</header>" +
-                "<content><content-prefix><b>this is the content</b><content-suffix></content>");
+        thenOutputIs("""
+                <header>this is the header</header>\
+                <content><content-prefix><b>this is the content</b><content-suffix></content>\
+                """);
     }
 
     @Test
     void layoutWithNamedParams() {
         givenLayout("main",
-                "@param status:Int = 5\n" +
-                "@param duration:Int = -1\n" +
-                "@param content:gg.jte.Content\n" +
-                "Hello, ${content} your status is ${status}, the duration is ${duration}");
+                """
+                @param status:Int = 5
+                @param duration:Int = -1
+                @param content:gg.jte.Content
+                Hello, ${content} your status is ${status}, the duration is ${duration}\
+                """);
 
-        givenTemplate("@template.layout.main(content = @`" +
-                "Sir`)");
+        givenTemplate("""
+                @template.layout.main(content = @`\
+                Sir`)\
+                """);
 
         thenOutputIs("Hello, Sir your status is 5, the duration is -1");
     }
@@ -910,10 +1021,12 @@ public class TemplateEngineTest {
     @Test
     void layoutWithNamedParams_noNames() {
         givenLayout("main",
-                "@param status:Int = 5\n" +
-                "@param duration:Int = -1\n" +
-                "@param content:gg.jte.Content\n" +
-                "Hello, ${content} your status is ${status}, the duration is ${duration}");
+                """
+                @param status:Int = 5
+                @param duration:Int = -1
+                @param content:gg.jte.Content
+                Hello, ${content} your status is ${status}, the duration is ${duration}\
+                """);
 
         givenTemplate("@template.layout.main(42, 10, @`Sir`)");
 
@@ -923,8 +1036,10 @@ public class TemplateEngineTest {
     @Test
     void layoutWithVarArgs() {
         givenLayout("varargs",
-                "@param vararg values:String\n" +
-                        "@for(value in values)${value} @endfor");
+                """
+                @param vararg values:String
+                @for(value in values)${value} @endfor\
+                """);
         givenTemplate("@template.layout.varargs(\"Hello\", \"World\")");
         thenOutputIs("Hello World ");
     }
@@ -932,14 +1047,16 @@ public class TemplateEngineTest {
     @Test
     void enumCheck() {
         givenRawTemplate(
-                "@import gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                        "@import gg.jte.kotlin.TemplateEngineTest.ModelType\n" +
-                        "@param model:Model\n" +
-                        "@if (model.type == ModelType.One)" +
-                        "one" +
-                        "@else" +
-                        "not one" +
-                        "@endif");
+                """
+                @import gg.jte.kotlin.TemplateEngineTest.Model
+                @import gg.jte.kotlin.TemplateEngineTest.ModelType
+                @param model:Model
+                @if (model.type == ModelType.One)\
+                one\
+                @else\
+                not one\
+                @endif\
+                """);
 
         model.type = ModelType.One;
         thenOutputIs("one");
@@ -957,27 +1074,31 @@ public class TemplateEngineTest {
 
     @Test
     void nestedJavascript() {
-        givenTemplate("@if (model.isCaseA() && model.isCaseB())\n" +
-                "        <meta name=\"robots\" content=\"a, b\">\n" +
-                "        @elseif (model.isCaseB())\n" +
-                "        <meta name=\"robots\" content=\"b\">\n" +
-                "        @elseif (model.isCaseA())\n" +
-                "        <meta name=\"robots\" content=\"a\">\n" +
-                "        @endif" +
-                "@if (model.x > 0)\n" +
-                "        <meta name=\"description\" content=\"${model.x}\">\n" +
-                "        @endif\n" +
-                "\n" +
-                "        <script>\n" +
-                "            function readCookie(name) {");
-        thenOutputIs("\n" +
-                "        <meta name=\"robots\" content=\"a\">\n" +
-                "        \n" +
-                "        <meta name=\"description\" content=\"42\">\n" +
-                "        \n" +
-                "\n" +
-                "        <script>\n" +
-                "            function readCookie(name) {");
+        givenTemplate("""
+                @if (model.isCaseA() && model.isCaseB())
+                        <meta name="robots" content="a, b">
+                        @elseif (model.isCaseB())
+                        <meta name="robots" content="b">
+                        @elseif (model.isCaseA())
+                        <meta name="robots" content="a">
+                        @endif\
+                @if (model.x > 0)
+                        <meta name="description" content="${model.x}">
+                        @endif
+                
+                        <script>
+                            function readCookie(name) {\
+                """);
+        thenOutputIs("""
+                
+                        <meta name="robots" content="a">
+                       \s
+                        <meta name="description" content="42">
+                       \s
+                
+                        <script>
+                            function readCookie(name) {\
+                """);
     }
 
     @Test
@@ -1010,11 +1131,13 @@ public class TemplateEngineTest {
     @Test
     void exceptionLineNumber1() {
         givenRawTemplate(
-                "@import gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                "\n" +
-                "@param model:gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                "\n" +
-                "${model.getThatThrows()}\n"
+                """
+                @import gg.jte.kotlin.TemplateEngineTest.Model
+                
+                @param model:gg.jte.kotlin.TemplateEngineTest.Model
+                
+                ${model.getThatThrows()}
+                """
         );
         thenRenderingFailsWithException()
                 .hasCauseInstanceOf(NullPointerException.class)
@@ -1025,11 +1148,15 @@ public class TemplateEngineTest {
     @Test
     void exceptionLineNumber2() {
         givenRawTemplate(
-                "@import gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                        "\n\n\n" +
-                        "@param model:gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                        "\n" +
-                        "${model.getThatThrows()}\n"
+                """
+                @import gg.jte.kotlin.TemplateEngineTest.Model
+                
+                
+                
+                @param model:gg.jte.kotlin.TemplateEngineTest.Model
+                
+                ${model.getThatThrows()}
+                """
         );
         thenRenderingFailsWithException()
                 .hasCauseInstanceOf(NullPointerException.class)
@@ -1039,11 +1166,13 @@ public class TemplateEngineTest {
     @Test
     void exceptionLineNumber3() {
         givenRawTemplate(
-                "@import gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                        "\n" +
-                        "@param model:gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                        "\n" +
-                        "${model.hello} ${model.getThatThrows()}\n"
+                """
+                @import gg.jte.kotlin.TemplateEngineTest.Model
+                
+                @param model:gg.jte.kotlin.TemplateEngineTest.Model
+                
+                ${model.hello} ${model.getThatThrows()}
+                """
         );
         thenRenderingFailsWithException()
                 .hasCauseInstanceOf(NullPointerException.class)
@@ -1053,15 +1182,17 @@ public class TemplateEngineTest {
     @Test
     void exceptionLineNumber4() {
         givenRawTemplate(
-                "@import gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                        "\n" +
-                        "@param model:gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                        "\n" +
-                        "${model.hello}\n" +
-                        "@for(i in 1..3)\n" +
-                        "\t${i}\n" +
-                        "\t${model.getThatThrows()}\n" +
-                        "@endfor\n"
+                """
+                @import gg.jte.kotlin.TemplateEngineTest.Model
+                
+                @param model:gg.jte.kotlin.TemplateEngineTest.Model
+                
+                ${model.hello}
+                @for(i in 1..3)
+                	${i}
+                	${model.getThatThrows()}
+                @endfor
+                """
         );
         thenRenderingFailsWithException()
                 .hasCauseInstanceOf(NullPointerException.class)
@@ -1070,10 +1201,12 @@ public class TemplateEngineTest {
 
     @Test
     void exceptionLineNumber5() {
-        givenTag("model", "@param model:gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                "@param i:Int = 0\n" +
-                "i is: ${i}\n" +
-                "${model.getThatThrows()}");
+        givenTag("model", """
+                @param model:gg.jte.kotlin.TemplateEngineTest.Model
+                @param i:Int = 0
+                i is: ${i}
+                ${model.getThatThrows()}\
+                """);
         givenTemplate("@template.tag.model(model)");
 
         thenRenderingFailsWithException()
@@ -1085,12 +1218,13 @@ public class TemplateEngineTest {
 
     @Test
     void exceptionLineNumber6() {
-        givenTag("model", "@param model:gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                "@param i:Int = 0\n" +
-                "i is: ${i}\n" +
-                "${model.getThatThrows()}");
+        givenTag("model", """
+                @param model:gg.jte.kotlin.TemplateEngineTest.Model
+                @param i:Int = 0
+                i is: ${i}
+                ${model.getThatThrows()}\
+                """);
 
-        @SuppressWarnings("resource")
         StringOutput output = new StringOutput();
         Throwable throwable = catchThrowable(() -> templateEngine.render("tag/model.kte", TemplateUtils.toMap("model", model, "i", 1L), output));
 
@@ -1142,9 +1276,11 @@ public class TemplateEngineTest {
 
     @Test
     void compileError3() {
-        givenTemplate("${model.hello}\n" +
-                "${model.hello}\n" +
-                "${model.helloUnknown}");
+        givenTemplate("""
+                ${model.hello}
+                ${model.hello}
+                ${model.helloUnknown}\
+                """);
 
         thenRenderingFailsWithException()
                 .hasMessageStartingWith("Failed to compile template, error at test/template.kte:4\n")
@@ -1164,11 +1300,15 @@ public class TemplateEngineTest {
 
     @Test
     void compileError5() {
-        givenTag("test", "@param model:gg.jte.kotlin.TemplateEngineTest.Model\n" +
-                "${\n" +
-                "@`\n" +
-                "This will not compile!\n${model.helloUnknown}\n!!\n" +
-                "`}");
+        givenTag("test", """
+                @param model:gg.jte.kotlin.TemplateEngineTest.Model
+                ${
+                @`
+                This will not compile!
+                ${model.helloUnknown}
+                !!
+                `}\
+                """);
         givenTemplate("@template.tag.test(model)");
         thenRenderingFailsWithException()
                 .hasMessageStartingWith("Failed to compile template, error at tag/test.kte:5\n")
@@ -1178,11 +1318,15 @@ public class TemplateEngineTest {
 
     @Test
     void compileError6() {
-        givenTag("test", "@param model:gg.jte.TemplateEngineTest.Model\n" +
-                "test");
-        givenTemplate("@template.tag.test(\n" +
-                "model = model,\n" +
-                "param2 = \"foo\")");
+        givenTag("test", """
+                @param model:gg.jte.TemplateEngineTest.Model
+                test\
+                """);
+        givenTemplate("""
+                @template.tag.test(
+                model = model,
+                param2 = "foo")\
+                """);
         thenRenderingFailsWithException()
                 .hasMessage("Failed to compile template, error at test/template.kte:3. No parameter with name param2 is defined in tag/test.kte");
     }
@@ -1304,11 +1448,13 @@ public class TemplateEngineTest {
 
     @Test
     void nestedKotlinStringTemplates() {
-        givenRawTemplate("@import java.time.format.DateTimeFormatter\n" +
-                "@import java.time.LocalDateTime\n" +
-                "@param now: LocalDateTime\n" +
-                "@param datePattern: String\n" +
-                "println(\"Today is ${now.format(DateTimeFormatter.ofPattern(\"${datePattern} HH:mm\"))}\")");
+        givenRawTemplate("""
+                @import java.time.format.DateTimeFormatter
+                @import java.time.LocalDateTime
+                @param now: LocalDateTime
+                @param datePattern: String
+                println("Today is ${now.format(DateTimeFormatter.ofPattern("${datePattern} HH:mm"))}")\
+                """);
 
         LocalDateTime now = LocalDateTime.of(2021, 8, 21, 7, 50);
 
@@ -1320,11 +1466,13 @@ public class TemplateEngineTest {
 
     @Test
     void nestedKotlinStringTemplates_unsafe() {
-        givenRawTemplate("@import java.time.format.DateTimeFormatter\n" +
-                "@import java.time.LocalDateTime\n" +
-                "@param now: LocalDateTime\n" +
-                "@param datePattern: String\n" +
-                "println(\"Today is $unsafe{now.format(DateTimeFormatter.ofPattern(\"${datePattern} HH:mm\"))}\")");
+        givenRawTemplate("""
+                @import java.time.format.DateTimeFormatter
+                @import java.time.LocalDateTime
+                @param now: LocalDateTime
+                @param datePattern: String
+                println("Today is $unsafe{now.format(DateTimeFormatter.ofPattern("${datePattern} HH:mm"))}")\
+                """);
 
         LocalDateTime now = LocalDateTime.of(2021, 8, 21, 7, 50);
 
@@ -1336,12 +1484,14 @@ public class TemplateEngineTest {
 
     @Test
     void nestedKotlinStringTemplates_variable() {
-        givenRawTemplate("@import java.time.format.DateTimeFormatter\n" +
-                "@import java.time.LocalDateTime\n" +
-                "@param now: LocalDateTime\n" +
-                "@param datePattern: String\n" +
-                "!{val variable = now.format(DateTimeFormatter.ofPattern(\"${datePattern} HH:mm\"))}" +
-                "println(\"Today is ${variable}\")");
+        givenRawTemplate("""
+                @import java.time.format.DateTimeFormatter
+                @import java.time.LocalDateTime
+                @param now: LocalDateTime
+                @param datePattern: String
+                !{val variable = now.format(DateTimeFormatter.ofPattern("${datePattern} HH:mm"))}\
+                println("Today is ${variable}")\
+                """);
 
         LocalDateTime now = LocalDateTime.of(2021, 8, 21, 7, 50);
 
@@ -1359,17 +1509,21 @@ public class TemplateEngineTest {
 
     @Test
     void rawWithJavaScript() {
-        givenTemplate("@raw\n" +
-                      "<script>\n" +
-                      "  const foo = \"foo\";\n" +
-                      "  console.log(`This is ${foo}`);\n" +
-                      "</script>\n" +
-                      "@endraw");
-        thenOutputIs("\n" +
-                     "<script>\n" +
-                     "  const foo = \"foo\";\n" +
-                     "  console.log(`This is ${foo}`);\n" +
-                     "</script>\n");
+        givenTemplate("""
+                      @raw
+                      <script>
+                        const foo = "foo";
+                        console.log(`This is ${foo}`);
+                      </script>
+                      @endraw\
+                      """);
+        thenOutputIs("""
+                     
+                     <script>
+                       const foo = "foo";
+                       console.log(`This is ${foo}`);
+                     </script>
+                     """);
     }
 
     @Test

--- a/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngine_HtmlInterceptorTest.java
+++ b/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngine_HtmlInterceptorTest.java
@@ -32,9 +32,11 @@ public class TemplateEngine_HtmlInterceptorTest {
 
     @Test
     void noFields_additionalFieldWritten() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<form action=\"${url}\">\n" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <form action="${url}">
+                </form>\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
@@ -43,77 +45,95 @@ public class TemplateEngine_HtmlInterceptorTest {
 
     @Test
     void formInIf() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "@if(true)\n" +
-                "    <form action=\"${url}\">\n" +
-                "        <input name=\"x\"/>\n" +
-                "    </form>" +
-                "@endif");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                @if(true)
+                    <form action="${url}">
+                        <input name="x"/>
+                    </form>\
+                @endif\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "    <input name=\"x\" value=\"?\"/>\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:x\">\n" +
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                    <input name="x" value="?"/>
+                <input name="__fp" value="a:hello.htm, p:x">
+                </form>\
+                """);
     }
 
     @Test
     void input() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<form action=\"${url}\">\n" +
-                "<input name=\"param1\">\n" +
-                "<input name=\"param2\">\n" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <form action="${url}">
+                <input name="param1">
+                <input name="param2">
+                </form>\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<input name=\"param1\" value=\"?\">\n" +
-                "<input name=\"param2\" value=\"?\">\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:param1,param2\">\n" +
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <input name="param1" value="?">
+                <input name="param2" value="?">
+                <input name="__fp" value="a:hello.htm, p:param1,param2">
+                </form>\
+                """);
     }
 
     @Test
     void input_int() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<form action=\"${url}\">\n" +
-                "<input name=\"age\" value=\"${23}\">\n" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <form action="${url}">
+                <input name="age" value="${23}">
+                </form>\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<input name=\"age\" value=\"23\">\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:age\">\n" +
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <input name="age" value="23">
+                <input name="__fp" value="a:hello.htm, p:age">
+                </form>\
+                """);
     }
 
     @Test
     void input_closed1() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<form action=\"${url}\">\n" +
-                "<input name=\"param1\"/>\n" +
-                "<input name=\"param2\"/>\n" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <form action="${url}">
+                <input name="param1"/>
+                <input name="param2"/>
+                </form>\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<input name=\"param1\" value=\"?\"/>\n" +
-                "<input name=\"param2\" value=\"?\"/>\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:param1,param2\">\n" +
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <input name="param1" value="?"/>
+                <input name="param2" value="?"/>
+                <input name="__fp" value="a:hello.htm, p:param1,param2">
+                </form>\
+                """);
     }
 
     @Test
     void input_closedWrongly() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<form action=\"${url}\">\n" +
-                "<input name=\"param1\"></input>\n" +
-                "<input name=\"param2\"></input>\n" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <form action="${url}">
+                <input name="param1"></input>
+                <input name="param2"></input>
+                </form>\
+                """);
 
         Throwable throwable = catchThrowable(() -> templateEngine.render("page.kte", "hello.htm", output));
 
@@ -122,8 +142,10 @@ public class TemplateEngine_HtmlInterceptorTest {
 
     @Test
     void input_noAttributes() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<input>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <input>\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
@@ -132,164 +154,196 @@ public class TemplateEngine_HtmlInterceptorTest {
 
     @Test
     void input_disabled() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<form action=\"${url}\">\n" +
-                "<input name=\"param1\" disabled>\n" +
-                "<input name=\"param2\">\n" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <form action="${url}">
+                <input name="param1" disabled>
+                <input name="param2">
+                </form>\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<input name=\"param1\" disabled value=\"?\">\n" +
-                "<input name=\"param2\" value=\"?\">\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:param2\">\n" + // No param1 here
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <input name="param1" disabled value="?">
+                <input name="param2" value="?">
+                <input name="__fp" value="a:hello.htm, p:param2">
+                </form>\
+                """);
     }
 
     @Test
     void select() {
-        dummyCodeResolver.givenCode("page.kte", "@param controller:gg.jte.kotlin.TemplateEngine_HtmlInterceptorTest.Controller\n" +
-                "<form action=\"${controller.url}\">\n" +
-                "<select name=\"foodOption\">\n" +
-                "@for(foodOption in controller.foodOptions)" +
-                "<option value=\"${foodOption}\">Mmmh, ${foodOption}</option>\n" +
-                "@endfor" +
-                "</select>\n" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param controller:gg.jte.kotlin.TemplateEngine_HtmlInterceptorTest.Controller
+                <form action="${controller.url}">
+                <select name="foodOption">
+                @for(foodOption in controller.foodOptions)\
+                <option value="${foodOption}">Mmmh, ${foodOption}</option>
+                @endfor\
+                </select>
+                </form>\
+                """);
 
         controller.setFoodOption("Onion");
         templateEngine.render("page.kte", controller, output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<select name=\"foodOption\">\n" +
-                "<option value=\"Cheese\">Mmmh, Cheese</option>\n" +
-                "<option value=\"Onion\" selected>Mmmh, Onion</option>\n" +
-                "<option value=\"Chili\">Mmmh, Chili</option>\n" +
-                "</select>\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:foodOption\">\n" +
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <select name="foodOption">
+                <option value="Cheese">Mmmh, Cheese</option>
+                <option value="Onion" selected>Mmmh, Onion</option>
+                <option value="Chili">Mmmh, Chili</option>
+                </select>
+                <input name="__fp" value="a:hello.htm, p:foodOption">
+                </form>\
+                """);
     }
 
     @Test
     void tag() {
         dummyCodeResolver.givenCode("tag/formContent.kte",
-                "<input name=\"param1\"></input>\n" +
-                "<input name=\"param2\"></input>\n");
+                """
+                <input name="param1"></input>
+                <input name="param2"></input>
+                """);
 
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<form action=\"${url}\">\n" +
-                "@template.tag.formContent()" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <form action="${url}">
+                @template.tag.formContent()\
+                </form>\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<input name=\"param1\" value=\"?\"></input>\n" +
-                "<input name=\"param2\" value=\"?\"></input>\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:param1,param2\">\n" +
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <input name="param1" value="?"></input>
+                <input name="param2" value="?"></input>
+                <input name="__fp" value="a:hello.htm, p:param1,param2">
+                </form>\
+                """);
     }
 
     @Test
     void layout() {
         dummyCodeResolver.givenCode("layout/formContent.kte",
-                        "@param url:String\n" +
-                        "@param content:gg.jte.Content\n" +
-                        "<form action=\"${url}\">\n" +
-                        "${content}" +
-                        "</form>");
+                        """
+                        @param url:String
+                        @param content:gg.jte.Content
+                        <form action="${url}">
+                        ${content}\
+                        </form>\
+                        """);
 
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "@template.layout.formContent(url, content = @`" +
-                "<input name=\"param1\"></input>\n" +
-                "<input name=\"param2\"></input>\n" +
-                "`)");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                @template.layout.formContent(url, content = @`\
+                <input name="param1"></input>
+                <input name="param2"></input>
+                `)\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<input name=\"param1\" value=\"?\"></input>\n" +
-                "<input name=\"param2\" value=\"?\"></input>\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:param1,param2\">\n" +
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <input name="param1" value="?"></input>
+                <input name="param2" value="?"></input>
+                <input name="__fp" value="a:hello.htm, p:param1,param2">
+                </form>\
+                """);
     }
 
     @Test
     void form() {
-        dummyCodeResolver.givenCode("page.kte", "@param controller:gg.jte.kotlin.TemplateEngine_HtmlInterceptorTest.Controller\n"
-              + "<body>\n"
-              + "   <h1>Hello</h1>\n"
-              + "\n"
-              + "   <form action=\"${controller.getUrl()}\" method=\"POST\">\n"
-              + "\n"
-              + "      <label>\n"
-              + "         Food option:\n"
-              + "         <select name=\"foodOption\">\n"
-              + "            <option value=\"\">-</option>\n"
-              + "            @for(foodOption in controller.getFoodOptions())\n"
-              + "               <option value=\"${foodOption}\">${foodOption}</option>\n"
-              + "            @endfor\n"
-              + "         </select>\n"
-              + "      </label>\n"
-              + "\n"
-              + "      <button type=\"submit\">Submit</button>\n"
-              + "   </form>\n"
-              + "</body>");
+        dummyCodeResolver.givenCode("page.kte", """
+              @param controller:gg.jte.kotlin.TemplateEngine_HtmlInterceptorTest.Controller
+              <body>
+                 <h1>Hello</h1>
+              
+                 <form action="${controller.getUrl()}" method="POST">
+              
+                    <label>
+                       Food option:
+                       <select name="foodOption">
+                          <option value="">-</option>
+                          @for(foodOption in controller.getFoodOptions())
+                             <option value="${foodOption}">${foodOption}</option>
+                          @endfor
+                       </select>
+                    </label>
+              
+                    <button type="submit">Submit</button>
+                 </form>
+              </body>\
+              """);
 
         templateEngine.render("page.kte", controller, output);
 
-        assertThat(output.toString()).isEqualTo("<body>\n"
-              + "   <h1>Hello</h1>\n"
-              + "\n"
-              + "   <form action=\"hello.htm\" method=\"POST\" data-form=\"x\">\n"
-              + "\n"
-              + "      <label>\n"
-              + "         Food option:\n"
-              + "         <select name=\"foodOption\">\n"
-              + "            <option value=\"\">-</option>\n"
-              + "            <option value=\"Cheese\">Cheese</option>\n"
-              + "            <option value=\"Onion\">Onion</option>\n"
-              + "            <option value=\"Chili\">Chili</option>\n"
-              + "         </select>\n"
-              + "      </label>\n"
-              + "\n"
-              + "      <button type=\"submit\">Submit</button>\n"
-              + "   <input name=\"__fp\" value=\"a:hello.htm, p:foodOption\">\n"
-              + "</form>\n"
-              + "</body>");
+        assertThat(output.toString()).isEqualTo("""
+              <body>
+                 <h1>Hello</h1>
+              
+                 <form action="hello.htm" method="POST" data-form="x">
+              
+                    <label>
+                       Food option:
+                       <select name="foodOption">
+                          <option value="">-</option>
+                          <option value="Cheese">Cheese</option>
+                          <option value="Onion">Onion</option>
+                          <option value="Chili">Chili</option>
+                       </select>
+                    </label>
+              
+                    <button type="submit">Submit</button>
+                 <input name="__fp" value="a:hello.htm, p:foodOption">
+              </form>
+              </body>\
+              """);
     }
 
     @Test
     void errorClass() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<form action=\"${url}\">\n" +
-                "<input name=\"error\" class=\"foo\">\n" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <form action="${url}">
+                <input name="error" class="foo">
+                </form>\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<input name=\"error\" class=\"foo\" value=\"?\" data-error=\"1\">\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:error\">\n" +
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <input name="error" class="foo" value="?" data-error="1">
+                <input name="__fp" value="a:hello.htm, p:error">
+                </form>\
+                """);
     }
 
     @Test
     void errorClass_indentation() {
-        dummyCodeResolver.givenCode("page.kte", "@param url:String\n" +
-                "<form action=\"${url}\">\n" +
-                "@if(true)\n" +
-                "    <input name=\"error\" class=\"foo\">\n" +
-                "@endif\n" +
-                "</form>");
+        dummyCodeResolver.givenCode("page.kte", """
+                @param url:String
+                <form action="${url}">
+                @if(true)
+                    <input name="error" class="foo">
+                @endif
+                </form>\
+                """);
 
         templateEngine.render("page.kte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<input name=\"error\" class=\"foo\" value=\"?\" data-error=\"1\">\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:error\">\n" +
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <input name="error" class="foo" value="?" data-error="1">
+                <input name="__fp" value="a:hello.htm, p:error">
+                </form>\
+                """);
     }
 
     @Test

--- a/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngine_HtmlOutputEscapingTest.java
+++ b/jte-kotlin/src/test/java/gg/jte/kotlin/TemplateEngine_HtmlOutputEscapingTest.java
@@ -32,9 +32,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
     @Test
     void outputEscaping() {
         codeResolver.givenCode("template.kte",
-                "@param url:String\n" +
-                "@param title:String\n" +
-                "Look at <a href=\"${url}\">${title}</a>");
+                """
+                @param url:String
+                @param title:String
+                Look at <a href="${url}">${title}</a>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("url", "https://www.test.com?param1=1&param2=2", "title", "<script>alert('hello');</script>"), output);
 
@@ -398,8 +400,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
         templateEngine.render("template.kte", "dummy", output);
 
-        assertThat(output.toString()).isEqualTo("<input id=\"login-email\" type=\"text\" placeholder=\"dummy\" required>\n" +
-                "<input id=\"login-password\" type=\"password\" placeholder=\"Savecode\" required>");
+        assertThat(output.toString()).isEqualTo("""
+                <input id="login-email" type="text" placeholder="dummy" required>
+                <input id="login-password" type="password" placeholder="Savecode" required>\
+                """);
     }
 
     @Test
@@ -777,47 +781,51 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void script4() {
-        codeResolver.givenCode("template.kte", "<div class=\"container\">\n" +
-                "    <script>\n" +
-                "        $(document).ready(function() {\n" +
-                "            var orderId = getUrlParameter('orderId');\n" +
-                "            $.get('shop/order?orderId=' + orderId, {}, function (data) {\n" +
-                "                var address = data.deliveryAddress.firstName + ' ' + data.deliveryAddress.lastName + '<br/>';\n" +
-                "                address += data.deliveryAddress.street + '<br/>';\n" +
-                "                if (data.deliveryAddress.company !== null && data.deliveryAddress.company.length > 0) {\n" +
-                "                    address += data.deliveryAddress.company + '<br/>';\n" +
-                "                }\n" +
-                "                address += data.deliveryAddress.postCode + '<br/>';\n" +
-                "                address += data.deliveryAddress.city + '<br/>';\n" +
-                "                address += data.deliveryAddress.country + '<br/>';\n" +
-                "                $('#shipping-address').html(address);\n" +
-                "                $('.physical-item').html(data.physicalItemName);\n" +
-                "            });\n" +
-                "        });\n" +
-                "    </script>\n" +
-                "</div>");
+        codeResolver.givenCode("template.kte", """
+                <div class="container">
+                    <script>
+                        $(document).ready(function() {
+                            var orderId = getUrlParameter('orderId');
+                            $.get('shop/order?orderId=' + orderId, {}, function (data) {
+                                var address = data.deliveryAddress.firstName + ' ' + data.deliveryAddress.lastName + '<br/>';
+                                address += data.deliveryAddress.street + '<br/>';
+                                if (data.deliveryAddress.company !== null && data.deliveryAddress.company.length > 0) {
+                                    address += data.deliveryAddress.company + '<br/>';
+                                }
+                                address += data.deliveryAddress.postCode + '<br/>';
+                                address += data.deliveryAddress.city + '<br/>';
+                                address += data.deliveryAddress.country + '<br/>';
+                                $('#shipping-address').html(address);
+                                $('.physical-item').html(data.physicalItemName);
+                            });
+                        });
+                    </script>
+                </div>\
+                """);
 
         templateEngine.render("template.kte", (Object)null, output);
 
-        assertThat(output.toString()).isEqualTo("<div class=\"container\">\n" +
-                "    <script>\n" +
-                "        $(document).ready(function() {\n" +
-                "            var orderId = getUrlParameter('orderId');\n" +
-                "            $.get('shop/order?orderId=' + orderId, {}, function (data) {\n" +
-                "                var address = data.deliveryAddress.firstName + ' ' + data.deliveryAddress.lastName + '<br/>';\n" +
-                "                address += data.deliveryAddress.street + '<br/>';\n" +
-                "                if (data.deliveryAddress.company !== null && data.deliveryAddress.company.length > 0) {\n" +
-                "                    address += data.deliveryAddress.company + '<br/>';\n" +
-                "                }\n" +
-                "                address += data.deliveryAddress.postCode + '<br/>';\n" +
-                "                address += data.deliveryAddress.city + '<br/>';\n" +
-                "                address += data.deliveryAddress.country + '<br/>';\n" +
-                "                $('#shipping-address').html(address);\n" +
-                "                $('.physical-item').html(data.physicalItemName);\n" +
-                "            });\n" +
-                "        });\n" +
-                "    </script>\n" +
-                "</div>");
+        assertThat(output.toString()).isEqualTo("""
+                <div class="container">
+                    <script>
+                        $(document).ready(function() {
+                            var orderId = getUrlParameter('orderId');
+                            $.get('shop/order?orderId=' + orderId, {}, function (data) {
+                                var address = data.deliveryAddress.firstName + ' ' + data.deliveryAddress.lastName + '<br/>';
+                                address += data.deliveryAddress.street + '<br/>';
+                                if (data.deliveryAddress.company !== null && data.deliveryAddress.company.length > 0) {
+                                    address += data.deliveryAddress.company + '<br/>';
+                                }
+                                address += data.deliveryAddress.postCode + '<br/>';
+                                address += data.deliveryAddress.city + '<br/>';
+                                address += data.deliveryAddress.country + '<br/>';
+                                $('#shipping-address').html(address);
+                                $('.physical-item').html(data.physicalItemName);
+                            });
+                        });
+                    </script>
+                </div>\
+                """);
     }
 
     @Test
@@ -843,35 +851,39 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void css() {
-        codeResolver.givenCode("template.kte", "<style type=\"text/css\">\n" +
-                "/*<![CDATA[*/\n" +
-                "body {\n" +
-                "\tcolor: #333333;\n" +
-                "\tline-height: 150%;\n" +
-                "}\n" +
-                "\n" +
-                "thead {\n" +
-                "\tfont-weight: bold;\n" +
-                "\tbackground-color: #CCCCCC;\n" +
-                "}\n" +
-                "/*]]>*/\n" +
-                "</style>");
+        codeResolver.givenCode("template.kte", """
+                <style type="text/css">
+                /*<![CDATA[*/
+                body {
+                	color: #333333;
+                	line-height: 150%;
+                }
+                
+                thead {
+                	font-weight: bold;
+                	background-color: #CCCCCC;
+                }
+                /*]]>*/
+                </style>\
+                """);
 
         templateEngine.render("template.kte", (Object)null, output);
 
-        assertThat(output.toString()).isEqualTo("<style type=\"text/css\">\n" +
-                "\n" +
-                "body {\n" +
-                "\tcolor: #333333;\n" +
-                "\tline-height: 150%;\n" +
-                "}\n" +
-                "\n" +
-                "thead {\n" +
-                "\tfont-weight: bold;\n" +
-                "\tbackground-color: #CCCCCC;\n" +
-                "}\n" +
-                "\n" +
-                "</style>");
+        assertThat(output.toString()).isEqualTo("""
+                <style type="text/css">
+                
+                body {
+                	color: #333333;
+                	line-height: 150%;
+                }
+                
+                thead {
+                	font-weight: bold;
+                	background-color: #CCCCCC;
+                }
+                
+                </style>\
+                """);
     }
 
     @Test
@@ -1021,9 +1033,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
     @Test
     void contentBlockInAttribute3() {
         codeResolver.givenCode("template.kte",
-                "@param url:String\n" +
-                "!{val content = @`<a href=\"${url}\" class=\"foo\">Hello</a>`}\n" +
-                "${content}");
+                """
+                @param url:String
+                !{val content = @`<a href="${url}" class="foo">Hello</a>`}
+                ${content}\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("url", "https://jte.gg"), output);
 
@@ -1033,14 +1047,18 @@ public class TemplateEngine_HtmlOutputEscapingTest {
     @Test
     void contentBlockInAttribute4() {
         codeResolver.givenCode("template.kte",
-                "@param url:String\n" +
-                        "!{val content = @`<a href=\"${url}\" class=\"foo\">Hello</a>`;}\n" +
-                        "<span data-content=\"${content}\">${content}</span>");
+                """
+                @param url:String
+                !{val content = @`<a href="${url}" class="foo">Hello</a>`;}
+                <span data-content="${content}">${content}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("url", "https://jte.gg"), output);
 
-        assertThat(output.toString()).isEqualTo("\n" +
-                "<span data-content=\"&lt;a href=&#34;https://jte.gg&#34; class=&#34;foo&#34;>Hello&lt;/a>\"><a href=\"https://jte.gg\" class=\"foo\">Hello</a></span>");
+        assertThat(output.toString()).isEqualTo("""
+                
+                <span data-content="&lt;a href=&#34;https://jte.gg&#34; class=&#34;foo&#34;>Hello&lt;/a>"><a href="https://jte.gg" class="foo">Hello</a></span>\
+                """);
     }
 
     @Test
@@ -1101,8 +1119,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_notFound_noParams() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "<span>${localizer.localize(\"unknown\")}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                <span>${localizer.localize("unknown")}</span>\
+                """);
 
         templateEngine.render("template.kte", localizer, output);
 
@@ -1111,8 +1131,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_notFound_withParams() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "<span>${localizer.localize(\"unknown\", 1)}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                <span>${localizer.localize("unknown", 1)}</span>\
+                """);
 
         templateEngine.render("template.kte", localizer, output);
 
@@ -1121,8 +1143,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_noParams() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "<span alt=\"${localizer.localize(\"no-params\")}\">${localizer.localize(\"no-params\")}</span>${localizer.localize(\"no-params\")}");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                <span alt="${localizer.localize("no-params")}">${localizer.localize("no-params")}</span>${localizer.localize("no-params")}\
+                """);
 
         templateEngine.render("template.kte", localizer, output);
 
@@ -1131,8 +1155,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_html() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "<span>${localizer.localize(\"no-params-html\")}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                <span>${localizer.localize("no-params-html")}</span>\
+                """);
 
         templateEngine.render("template.kte", localizer, output);
 
@@ -1141,9 +1167,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_oneParam() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param param:String\n" +
-                "<span>${localizer.localize(\"one-param\", param)}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param param:String
+                <span>${localizer.localize("one-param", param)}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "param", "<script>evil()</script>"), output);
 
@@ -1152,9 +1180,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_html_oneParam() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param param:String\n" +
-                "<span>${localizer.localize(\"one-param-html\", param)}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param param:String
+                <span>${localizer.localize("one-param-html", param)}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "param", "<script>evil()</script>"), output);
 
@@ -1163,9 +1193,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_inception() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param param:String\n" +
-                "<span>${localizer.localize(\"one-param-html\", localizer.localize(\"one-param-html\", param))}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param param:String
+                <span>${localizer.localize("one-param-html", localizer.localize("one-param-html", param))}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "param", "<script>evil()</script>"), output);
 
@@ -1174,8 +1206,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_quotesInAttribute() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "<span data-title=\"${localizer.localize(\"quotes\")}\"></span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                <span data-title="${localizer.localize("quotes")}"></span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer), output);
 
@@ -1184,11 +1218,13 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_quotesInAttributeWithParams() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param p1:String\n" +
-                "@param p2:String\n" +
-                "@param p3:String\n" +
-                "<span data-title=\"${localizer.localize(\"quotes-params\", p1, p2, p3)}\"></span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param p1:String
+                @param p2:String
+                @param p3:String
+                <span data-title="${localizer.localize("quotes-params", p1, p2, p3)}"></span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "p1", "<script>evil()</script>", "p2", "p2", "p3", "p3"), output);
 
@@ -1197,9 +1233,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_manyParams_noneSet() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param param:String\n" +
-                "<span>${localizer.localize(\"many-params-html\")}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param param:String
+                <span>${localizer.localize("many-params-html")}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "param", "<script>evil()</script>"), output);
 
@@ -1208,9 +1246,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_manyParams_primitives() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param param:String?\n" +
-                "<span>${localizer.localize(\"many-params-html\")}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param param:String?
+                <span>${localizer.localize("many-params-html")}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "p1", true, "p2", 1, "p3", 2), output);
 
@@ -1219,9 +1259,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_manyParams_oneSet() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param param:String\n" +
-                "<span>${localizer.localize(\"many-params-html\", param)}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param param:String
+                <span>${localizer.localize("many-params-html", param)}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "param", "<script>evil()</script>"), output);
 
@@ -1230,9 +1272,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_manyParams_allSame() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param param:String\n" +
-                "<span>${localizer.localize(\"many-params-html\", param, param, param)}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param param:String
+                <span>${localizer.localize("many-params-html", param, param, param)}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "param", "<script>evil()</script>"), output);
 
@@ -1241,9 +1285,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_badPattern() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param param:String\n" +
-                "<span>${localizer.localize(\"bad-pattern\", param)}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param param:String
+                <span>${localizer.localize("bad-pattern", param)}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "param", "<script>evil()</script>"), output);
 
@@ -1252,8 +1298,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_primitives() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "<span>${localizer.localize(\"all-primitives\", false, 1.toByte(), 2.toShort(), 3, 4L, 5.0f, 6.0, 'c')}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                <span>${localizer.localize("all-primitives", false, 1.toByte(), 2.toShort(), 3, 4L, 5.0f, 6.0, 'c')}</span>\
+                """);
 
         templateEngine.render("template.kte", localizer, output);
 
@@ -1262,8 +1310,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_primitives_inAttribute() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "<span alt=\"${localizer.localize(\"all-primitives\", false, 1.toByte(), 2.toShort(), 3, 4L, 5.0f, 6.0, 'c')}\"></span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                <span alt="${localizer.localize("all-primitives", false, 1.toByte(), 2.toShort(), 3, 4L, 5.0f, 6.0, 'c')}"></span>\
+                """);
 
         templateEngine.render("template.kte", localizer, output);
 
@@ -1272,9 +1322,11 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_enum() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param contentType:gg.jte.ContentType\n" +
-                "<span alt=\"${localizer.localize(\"enum\", contentType)}\">${localizer.localize(\"enum\", contentType)}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param contentType:gg.jte.ContentType
+                <span alt="${localizer.localize("enum", contentType)}">${localizer.localize("enum", contentType)}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "contentType", ContentType.Html), output);
 
@@ -1283,11 +1335,15 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag() {
-        codeResolver.givenCode("tag/card.kte", "@param content:gg.jte.Content\n" +
-                    "<span>${content}</span>");
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param name:String\n" +
-                "@template.tag.card(content = @`<b>${localizer.localize(\"one-param\", name)}</b>`)");
+        codeResolver.givenCode("tag/card.kte", """
+                    @param content:gg.jte.Content
+                    <span>${content}</span>\
+                    """);
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param name:String
+                @template.tag.card(content = @`<b>${localizer.localize("one-param", name)}</b>`)\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "name", "<script>"), output);
 
@@ -1296,11 +1352,15 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag2() {
-        codeResolver.givenCode("tag/card.kte", "@param content:gg.jte.Content\n" +
-                "<span>${content}</span>");
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param name:String\n" +
-                "@template.tag.card(content = localizer.localize(\"one-param\", name))");
+        codeResolver.givenCode("tag/card.kte", """
+                @param content:gg.jte.Content
+                <span>${content}</span>\
+                """);
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param name:String
+                @template.tag.card(content = localizer.localize("one-param", name))\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "name", "<script>"), output);
 
@@ -1309,11 +1369,15 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag3() {
-        codeResolver.givenCode("tag/card.kte", "@param content:gg.jte.Content\n" +
-                "<span>${content}</span>");
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param name:String\n" +
-                "@template.tag.card(content = localizer.localize(\"one-param\", @`<b>${name}</b>`))");
+        codeResolver.givenCode("tag/card.kte", """
+                @param content:gg.jte.Content
+                <span>${content}</span>\
+                """);
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param name:String
+                @template.tag.card(content = localizer.localize("one-param", @`<b>${name}</b>`))\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "name", "<script>"), output);
 
@@ -1322,11 +1386,15 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag4() {
-        codeResolver.givenCode("tag/card.kte", "@param content:gg.jte.Content\n" +
-                "<span>${content}</span>");
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param name:String\n" +
-                "@template.tag.card(content = localizer.localize(\"many-params-html\", @`<span>${name}</span>`, @`<span>${name}</span>`, @`<span>${name}</span>`))");
+        codeResolver.givenCode("tag/card.kte", """
+                @param content:gg.jte.Content
+                <span>${content}</span>\
+                """);
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param name:String
+                @template.tag.card(content = localizer.localize("many-params-html", @`<span>${name}</span>`, @`<span>${name}</span>`, @`<span>${name}</span>`))\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "name", "<script>"), output);
 
@@ -1335,13 +1403,17 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag5() {
-        codeResolver.givenCode("tag/card.kte", "@param content:gg.jte.Content\n" +
-                "<span>${content}</span>");
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param name:String\n" +
-                "@template.tag.card(content = localizer.localize(\"one-param\", @`<b>" +
-                    "${localizer.localize(\"one-param-html\", @`<i>${name}</i>`)}" +
-                "</b>`))");
+        codeResolver.givenCode("tag/card.kte", """
+                @param content:gg.jte.Content
+                <span>${content}</span>\
+                """);
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param name:String
+                @template.tag.card(content = localizer.localize("one-param", @`<b>\
+                ${localizer.localize("one-param-html", @`<i>${name}</i>`)}\
+                </b>`))\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "name", "<script>"), output);
 
@@ -1350,13 +1422,17 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag6() {
-        codeResolver.givenCode("tag/card.kte", "@param content:gg.jte.Content\n" +
-                "<span>${content}</span>");
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param name:String\n" +
-                "@template.tag.card(content = localizer.localize(\"one-param\", @`<b>" +
-                    "@template.tag.card(content = localizer.localize(\"one-param-html\", @`<i>${name}</i>`))" +
-                "</b>`))");
+        codeResolver.givenCode("tag/card.kte", """
+                @param content:gg.jte.Content
+                <span>${content}</span>\
+                """);
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param name:String
+                @template.tag.card(content = localizer.localize("one-param", @`<b>\
+                @template.tag.card(content = localizer.localize("one-param-html", @`<i>${name}</i>`))\
+                </b>`))\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "name", "<script>"), output);
 
@@ -1365,14 +1441,18 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag7() {
-        codeResolver.givenCode("tag/card.kte", "@param content:gg.jte.Content\n" +
-                "<span>${content}</span>");
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "@param name:String\n" +
-                "!{var content = localizer.localize(\"one-param\", @`<b>" +
-                "${localizer.localize(\"one-param-html\", @`<i>${name}</i>`)}" +
-                "</b>`);}" +
-                "@template.tag.card(content = content)");
+        codeResolver.givenCode("tag/card.kte", """
+                @param content:gg.jte.Content
+                <span>${content}</span>\
+                """);
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                @param name:String
+                !{var content = localizer.localize("one-param", @`<b>\
+                ${localizer.localize("one-param-html", @`<i>${name}</i>`)}\
+                </b>`);}\
+                @template.tag.card(content = content)\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "name", "<script>"), output);
 
@@ -1381,8 +1461,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag8() {
-        codeResolver.givenCode("tag/card.kte", "@param content:gg.jte.Content = @`My default is ${42}`\n" +
-                "<span>${content}</span>");
+        codeResolver.givenCode("tag/card.kte", """
+                @param content:gg.jte.Content = @`My default is ${42}`
+                <span>${content}</span>\
+                """);
         codeResolver.givenCode("template.kte", "@template.tag.card()");
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer, "name", "<script>"), output);
@@ -1392,8 +1474,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_contentParams() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "<span>${localizer.localize(\"link\", @`<a href=\"${\"foo\"}\">`, @`</a>`)}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                <span>${localizer.localize("link", @`<a href="${"foo"}">`, @`</a>`)}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer), output);
 
@@ -1402,8 +1486,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_contentParams2() {
-        codeResolver.givenCode("template.kte", "@param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer\n" +
-                "<span>${localizer.localize(\"link\", @`<a style=\"color: ${\"foo\"};\">`, @`</a>`)}</span>");
+        codeResolver.givenCode("template.kte", """
+                @param localizer:gg.jte.kotlin.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer
+                <span>${localizer.localize("link", @`<a style="color: ${"foo"};">`, @`</a>`)}</span>\
+                """);
 
         templateEngine.render("template.kte", TemplateUtils.toMap("localizer", localizer), output);
 

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
@@ -26,7 +26,7 @@ public class ModelConfig {
         } catch (IllegalArgumentException ex) {
             String supportedValues = Arrays.toString(Language.values());
             throw new IllegalArgumentException(
-                String.format("jte ModelExtension 'language' property is not configured correctly (current value is '%s'). Supported values: %s", configuredLanguage, supportedValues),
+                    "jte ModelExtension 'language' property is not configured correctly (current value is '%s'). Supported values: %s".formatted(configuredLanguage, supportedValues),
                 ex
             );
         }

--- a/jte-models/src/main/java/gg/jte/models/generator/Util.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/Util.java
@@ -10,7 +10,7 @@ public class Util {
     }
 
     public static String typedParams(TemplateDescription template) {
-        return template.params().stream().map(param -> String.format("%s %s", param.type(), param.name())).collect(Collectors.joining(", "));
+        return template.params().stream().map(param -> "%s %s".formatted(param.type(), param.name())).collect(Collectors.joining(", "));
     }
 
     public static String kotlinTypedParams(TemplateDescription template, boolean includeParamDefaultValue) {

--- a/jte-models/src/main/java/gg/jte/models/runtime/StaticJteModel.java
+++ b/jte-models/src/main/java/gg/jte/models/runtime/StaticJteModel.java
@@ -40,8 +40,8 @@ public class StaticJteModel<OUTPUT extends TemplateOutput> implements JteModel {
     }
 
     private TemplateException handleException(Exception e) {
-        if (e instanceof TemplateException) {
-            return (TemplateException) e;
+        if (e instanceof TemplateException exception) {
+            return exception;
         }
         StackTraceElement[] stackTrace = e.getStackTrace();
 

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
@@ -13,10 +13,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -61,7 +61,7 @@ public class TestModelExtension {
             // When
             Collection<Path> generatedPaths = modelExtension.generate(
                     config(Paths.get("target/generated-test-sources"), TEST_PACKAGE),
-                    Collections.singleton(templateDescription)
+                    Set.of(templateDescription)
             );
 
             // Then
@@ -125,7 +125,7 @@ public class TestModelExtension {
             // When
             Collection<Path> generatedPaths = modelExtension.generate(
                     config(Paths.get("target/generated-test-sources"), TEST_PACKAGE),
-                    Collections.singleton(templateDescription)
+                    Set.of(templateDescription)
             );
 
             // Then
@@ -172,7 +172,7 @@ public class TestModelExtension {
             // When
             Collection<Path> generatedPaths = modelExtension.generate(
                     config(Paths.get("target/generated-test-sources"), TEST_PACKAGE),
-                    Collections.singleton(templateDescription)
+                    Set.of(templateDescription)
             );
 
             // Then
@@ -216,7 +216,7 @@ public class TestModelExtension {
             // When
             Collection<Path> generatedPaths = modelExtension.generate(
                     config(Paths.get("target/generated-test-sources"), TEST_PACKAGE),
-                    Collections.singleton(templateDescription)
+                    Set.of(templateDescription)
             );
 
             // Then
@@ -266,10 +266,10 @@ public class TestModelExtension {
                 "DynamicTemplates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
                     package test.myktemplates
-                                         
+                    
                     import gg.jte.TemplateEngine
                     import gg.jte.models.runtime.*
-                                         
+                    
                     class DynamicTemplates(private val engine: TemplateEngine) : Templates {
                        \s
                         override fun hello(content: gg.jte.Content): JteModel {
@@ -281,7 +281,7 @@ public class TestModelExtension {
                            \s
                             return DynamicJteModel(engine, "hello.kte", paramMap)
                         }
-                                         
+                    
                     }""")
             );
             assertThat(actual).containsExactlyInAnyOrderEntriesOf(expected);
@@ -299,7 +299,7 @@ public class TestModelExtension {
             // When
             Collection<Path> generatedPaths = modelExtension.generate(
                     config(Paths.get("target/generated-test-sources"), TEST_PACKAGE),
-                    Collections.singleton(templateDescription)
+                    Set.of(templateDescription)
             );
 
             // Then
@@ -317,14 +317,14 @@ public class TestModelExtension {
                 "Templates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
                     package test.myktemplates
-                                         
+                    
                     import gg.jte.models.runtime.*
-                                         
+                    
                     interface Templates {
                        \s
                         @JteView("hello.kte")
                         fun hello(): JteModel
-                                         
+                    
                     }"""),
                 "StaticTemplates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
@@ -349,10 +349,10 @@ public class TestModelExtension {
                 "DynamicTemplates.kt", withSystemLineEndings("""
                     @file:Suppress("ktlint")
                     package test.myktemplates
-                                    
+                    
                     import gg.jte.TemplateEngine
                     import gg.jte.models.runtime.*
-                                    
+                    
                     class DynamicTemplates(private val engine: TemplateEngine) : Templates {
                        \s
                         override fun hello(): JteModel {

--- a/jte-native-resources/src/main/java/gg/jte/nativeimage/NativeResourcesExtension.java
+++ b/jte-native-resources/src/main/java/gg/jte/nativeimage/NativeResourcesExtension.java
@@ -46,7 +46,7 @@ public class NativeResourcesExtension implements JteExtension {
             writeFile(resourceRoot.resolve("reflection-config.json"),
                     templateDescriptions.stream()
                             .map(TemplateDescription::fullyQualifiedClassName)
-                            .map(className -> String.format("{\"name\":\"%s\", \"allDeclaredMethods\":true, \"allDeclaredFields\":true}", className))
+                            .map("{\"name\":\"%s\", \"allDeclaredMethods\":true, \"allDeclaredFields\":true}"::formatted)
                             .collect(Collectors.joining(",\n", "[\n", "\n]\n"))
             )
         );

--- a/jte-runtime/src/main/java/gg/jte/TemplateEngine.java
+++ b/jte-runtime/src/main/java/gg/jte/TemplateEngine.java
@@ -241,8 +241,8 @@ public final class TemplateEngine {
     }
 
     private TemplateException handleRenderException(String name, Template template, Throwable e) {
-        if (e instanceof TemplateException) {
-            return (TemplateException)e;
+        if (e instanceof TemplateException exception) {
+            return exception;
         }
 
         ClassLoader classLoader = template.getClassLoader();

--- a/jte-runtime/src/main/java/gg/jte/TemplateEngine.java
+++ b/jte-runtime/src/main/java/gg/jte/TemplateEngine.java
@@ -404,10 +404,7 @@ public final class TemplateEngine {
         TemplateEngine engine = createPrecompiled(classDirectory, contentType, parentClassLoader, config.packageName);
         engine.setHtmlInterceptor(htmlInterceptor);
 
-        Set<String> templates = new HashSet<>(templateCache.keySet());
-        for (String templateName : templates) {
-            engine.prepareForRendering(templateName);
-        }
+        templateCache.keySet().forEach(engine::prepareForRendering);
 
         return engine;
     }

--- a/jte-runtime/src/main/java/gg/jte/support/LocalizationSupport.java
+++ b/jte-runtime/src/main/java/gg/jte/support/LocalizationSupport.java
@@ -14,7 +14,7 @@ public interface LocalizationSupport {
     @SuppressWarnings("unused") // Called by template code
     default Content localize(String key) {
         String value = lookup(key);
-        if (value == null || value.length() == 0) {
+        if (value == null || value.isEmpty()) {
             return null;
         }
 
@@ -24,7 +24,7 @@ public interface LocalizationSupport {
     @SuppressWarnings("unused") // Called by template code
     default Content localize(String key, Object ... params) {
         String value = lookup(key);
-        if (value == null || value.length() == 0) {
+        if (value == null || value.isEmpty()) {
             return null;
         }
 

--- a/jte-runtime/src/main/java/gg/jte/support/LocalizationSupport.java
+++ b/jte-runtime/src/main/java/gg/jte/support/LocalizationSupport.java
@@ -56,28 +56,28 @@ public interface LocalizationSupport {
             }
 
             private void writeParam(TemplateOutput output, Object param) {
-                if (param instanceof String) {
-                    output.writeUserContent((String) param);
-                } else if (param instanceof Content) {
-                    output.writeUserContent((Content) param);
-                } else if (param instanceof Enum) {
-                    output.writeUserContent((Enum<?>) param);
-                } else if (param instanceof Boolean) {
-                    output.writeUserContent((boolean) param);
-                } else if (param instanceof Byte) {
-                    output.writeUserContent((byte) param);
-                } else if (param instanceof Short) {
-                    output.writeUserContent((short) param);
-                } else if (param instanceof Integer) {
-                    output.writeUserContent((int) param);
-                } else if (param instanceof Long) {
-                    output.writeUserContent((long) param);
-                } else if (param instanceof Float) {
-                    output.writeUserContent((float) param);
-                } else if (param instanceof Double) {
-                    output.writeUserContent((double) param);
-                } else if (param instanceof Character) {
-                    output.writeUserContent((char) param);
+                if (param instanceof String string) {
+                    output.writeUserContent(string);
+                } else if (param instanceof Content content) {
+                    output.writeUserContent(content);
+                } else if (param instanceof Enum<?> enum1) {
+                    output.writeUserContent(enum1);
+                } else if (param instanceof Boolean boolean1) {
+                    output.writeUserContent(boolean1);
+                } else if (param instanceof Byte byte1) {
+                    output.writeUserContent(byte1);
+                } else if (param instanceof Short short1) {
+                    output.writeUserContent(short1);
+                } else if (param instanceof Integer integer) {
+                    output.writeUserContent(integer);
+                } else if (param instanceof Long long1) {
+                    output.writeUserContent(long1);
+                } else if (param instanceof Float float1) {
+                    output.writeUserContent(float1);
+                } else if (param instanceof Double double1) {
+                    output.writeUserContent(double1);
+                } else if (param instanceof Character character) {
+                    output.writeUserContent(character);
                 }
             }
         };

--- a/jte/src/main/java/gg/jte/compiler/ClassUtils.java
+++ b/jte/src/main/java/gg/jte/compiler/ClassUtils.java
@@ -34,8 +34,8 @@ public final class ClassUtils {
             }
         }
 
-        if (classLoader instanceof URLClassLoader) {
-            for (URL url : ((URLClassLoader) classLoader).getURLs()) {
+        if (classLoader instanceof URLClassLoader loader) {
+            for (URL url : loader.getURLs()) {
                 String protocol = url.getProtocol();
 
                 if ("file".equalsIgnoreCase(protocol)) {

--- a/jte/src/main/java/gg/jte/compiler/LineInfo.java
+++ b/jte/src/main/java/gg/jte/compiler/LineInfo.java
@@ -7,9 +7,9 @@ import java.util.Collections;
 import java.util.List;
 
 final class LineInfo {
-    private static final List<TemplateParser.Mode> ConditionEndModes = Arrays.asList(TemplateParser.Mode.Condition, TemplateParser.Mode.Text);
-    private static final List<TemplateParser.Mode> ForLoopEndModes = Arrays.asList(TemplateParser.Mode.ForLoop, TemplateParser.Mode.Text);
-    private static final List<TemplateParser.Mode> RawEndModes = Collections.singletonList(TemplateParser.Mode.Raw);
+    private static final List<TemplateParser.Mode> ConditionEndModes = List.of(TemplateParser.Mode.Condition, TemplateParser.Mode.Text);
+    private static final List<TemplateParser.Mode> ForLoopEndModes = List.of(TemplateParser.Mode.ForLoop, TemplateParser.Mode.Text);
+    private static final List<TemplateParser.Mode> RawEndModes = List.of(TemplateParser.Mode.Raw);
 
     private LineInfo() {
     }

--- a/jte/src/main/java/gg/jte/compiler/TemplateCompiler.java
+++ b/jte/src/main/java/gg/jte/compiler/TemplateCompiler.java
@@ -47,13 +47,13 @@ public class TemplateCompiler extends TemplateLoader {
 
     @Override
     public Template load(String name) {
-        precompile(Collections.singletonList(name));
+        precompile(List.of(name));
         return super.load(name);
     }
 
     @Override
     public Template hotReload(String name) {
-        LinkedHashSet<ClassDefinition> classDefinitions = generate(Collections.singletonList(name), true);
+        LinkedHashSet<ClassDefinition> classDefinitions = generate(List.of(name), true);
         classDefinitions.removeIf(c -> !c.isChanged());
 
         if (!classDefinitions.isEmpty()) {
@@ -320,11 +320,11 @@ public class TemplateCompiler extends TemplateLoader {
         TemplateDependency dependency = new TemplateDependency(name, 0);
 
         List<String> result = new ArrayList<>();
-        for (Map.Entry<String, LinkedHashSet<TemplateDependency>> dependencies : templateDependencies.entrySet()) {
-            if (dependencies.getValue().contains(dependency)) {
-                result.add(dependencies.getKey());
+        templateDependencies.forEach((key, value) -> {
+            if (value.contains(dependency)) {
+                result.add(key);
             }
-        }
+        });
 
         return result;
     }

--- a/jte/src/main/java/gg/jte/compiler/TemplateParser.java
+++ b/jte/src/main/java/gg/jte/compiler/TemplateParser.java
@@ -408,8 +408,8 @@ public final class TemplateParser {
     }
 
     private int getCurrentTemplateLine() {
-        if (visitor instanceof CodeGenerator) {
-            return ((CodeGenerator)visitor).getCurrentTemplateLine();
+        if (visitor instanceof CodeGenerator generator) {
+            return generator.getCurrentTemplateLine();
         }
 
         return 0;

--- a/jte/src/main/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescription.java
+++ b/jte/src/main/java/gg/jte/compiler/extensionsupport/ExtensionTemplateDescription.java
@@ -35,7 +35,7 @@ public class ExtensionTemplateDescription implements TemplateDescription {
 
     @Override
     public List<ParamDescription> params() {
-        return new ArrayList<>(classDefinition.getParams());
+        return List.copyOf(classDefinition.getParams());
     }
 
     @Override

--- a/jte/src/test/java/gg/jte/DummyCodeResolver.java
+++ b/jte/src/test/java/gg/jte/DummyCodeResolver.java
@@ -24,6 +24,6 @@ public class DummyCodeResolver implements CodeResolver {
 
     @Override
     public List<String> resolveAllTemplateNames() {
-        return new ArrayList<>(codeLookup.keySet());
+        return List.copyOf(codeLookup.keySet());
     }
 }

--- a/jte/src/test/java/gg/jte/PreCompileTemplatesTest.java
+++ b/jte/src/test/java/gg/jte/PreCompileTemplatesTest.java
@@ -55,7 +55,7 @@ public class PreCompileTemplatesTest {
 
         String classPath = System.getProperty("java.class.path");
         if (classPath != null) {
-            result.addAll(Arrays.asList(classPath.split(File.pathSeparator)));
+            result.addAll(List.of(classPath.split(File.pathSeparator)));
         }
 
         return result;

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -157,11 +157,13 @@ public class TemplateEngineTest {
 
     @Test
     void condition_else() {
-        givenTemplate("@if (model.x == 42)" +
-                "Bingo" +
-                "@else" +
-                "Bongo" +
-                "@endif");
+        givenTemplate("""
+                @if (model.x == 42)\
+                Bingo\
+                @else\
+                Bongo\
+                @endif\
+                """);
 
         model.x = 42;
         thenOutputIs("Bingo");
@@ -171,11 +173,13 @@ public class TemplateEngineTest {
 
     @Test
     void condition_elseif() {
-        givenTemplate("@if (model.x == 42)" +
-                "Bingo" +
-                "@elseif (model.x == 43)" +
-                "Bongo" +
-                "@endif!");
+        givenTemplate("""
+                @if (model.x == 42)\
+                Bingo\
+                @elseif (model.x == 43)\
+                Bongo\
+                @endif!\
+                """);
 
         model.x = 42;
         thenOutputIs("Bingo!");
@@ -204,13 +208,15 @@ public class TemplateEngineTest {
     @Test
     void conditionInContentBlock() {
         model.x = 0;
-        givenTemplate("x is ${@`@if (model.x > 0)" +
-                "positive!" +
-                "@elseif(model.x < 0)" +
-                "negative!" +
-                "@else" +
-                "zero!" +
-                "@endif`}");
+        givenTemplate("""
+                x is ${@`@if (model.x > 0)\
+                positive!\
+                @elseif(model.x < 0)\
+                negative!\
+                @else\
+                zero!\
+                @endif`}\
+                """);
         thenOutputIs("x is zero!");
     }
 
@@ -226,73 +232,87 @@ public class TemplateEngineTest {
     @Test
     void loop() {
         model.array = new int[]{1, 2, 3};
-        givenTemplate("@for (int i : model.array)" +
-                "${i}" +
-                "@endfor");
+        givenTemplate("""
+                @for (int i : model.array)\
+                ${i}\
+                @endfor\
+                """);
         thenOutputIs("123");
     }
 
     @Test
     void loopWithCondition() {
         model.array = new int[]{1, 2, 3};
-        givenTemplate("@for (int i : model.array)" +
-                "@if (i > 1)" +
-                "${i}" +
-                "@endif" +
-                "@endfor");
+        givenTemplate("""
+                @for (int i : model.array)\
+                @if (i > 1)\
+                ${i}\
+                @endif\
+                @endfor\
+                """);
         thenOutputIs("23");
     }
 
     @Test
     void classicLoop() {
         model.array = new int[]{10, 20, 30};
-        givenTemplate("@for (int i = 0; i < model.array.length; ++i)" +
-                "Index ${i} is ${model.array[i]}" +
-                "@if (i < model.array.length - 1)" +
-                "<br>" +
-                "@endif" +
-                "@endfor");
+        givenTemplate("""
+                @for (int i = 0; i < model.array.length; ++i)\
+                Index ${i} is ${model.array[i]}\
+                @if (i < model.array.length - 1)\
+                <br>\
+                @endif\
+                @endfor\
+                """);
         thenOutputIs("Index 0 is 10<br>Index 1 is 20<br>Index 2 is 30");
     }
 
     @Test
     void loopWithVariable() {
         model.array = new int[]{1, 2, 3};
-        givenTemplate("@for (int i : model.array)" +
-                "!{int y = i + 1;}" +
-                "${y}" +
-                "@endfor");
+        givenTemplate("""
+                @for (int i : model.array)\
+                !{int y = i + 1;}\
+                ${y}\
+                @endfor\
+                """);
         thenOutputIs("234");
     }
 
     @Test
     void loopInContentBlock() {
         model.array = new int[]{1, 2, 3};
-        givenTemplate("${@`@for (int i : model.array)" +
-                "${i}" +
-                "@endfor`}");
+        givenTemplate("""
+                ${@`@for (int i : model.array)\
+                ${i}\
+                @endfor`}\
+                """);
         thenOutputIs("123");
     }
 
     @Test
     void loopElse_empty() {
         model.array = new int[]{};
-        givenTemplate("@for (int i : model.array)" +
-                "${i}" +
-                "@else" +
-                "Empty" +
-                "@endfor");
+        givenTemplate("""
+                @for (int i : model.array)\
+                ${i}\
+                @else\
+                Empty\
+                @endfor\
+                """);
         thenOutputIs("Empty");
     }
 
     @Test
     void loopElse_notEmpty() {
         model.array = new int[]{1};
-        givenTemplate("@for (int i : model.array)" +
-                "${i}" +
-                "@else" +
-                "Empty" +
-                "@endfor");
+        givenTemplate("""
+                @for (int i : model.array)\
+                ${i}\
+                @else\
+                Empty\
+                @endfor\
+                """);
         thenOutputIs("1");
     }
 
@@ -336,11 +356,13 @@ public class TemplateEngineTest {
     @Test
     void loopElse_if() {
         model.array = new int[]{};
-        givenTemplate("@for (int i : model.array)" +
-                "@if(i > 0)${i}@else@endif" +
-                "@else" +
-                "Empty" +
-                "@endfor");
+        givenTemplate("""
+                @for (int i : model.array)\
+                @if(i > 0)${i}@else@endif\
+                @else\
+                Empty\
+                @endfor\
+                """);
         thenOutputIs("Empty");
     }
 
@@ -369,16 +391,18 @@ public class TemplateEngineTest {
     @Test
     void loopElse_multiple() {
         model.array = new int[]{1};
-        givenTemplate("@for (int i : model.array)" +
-                "${i}" +
-                "@else" +
-                "Empty" +
-                "@endfor\n" +
-                "@for (int i : model.array)" +
-                "${i}" +
-                "@else" +
-                "Empty" +
-                "@endfor");
+        givenTemplate("""
+                @for (int i : model.array)\
+                ${i}\
+                @else\
+                Empty\
+                @endfor
+                @for (int i : model.array)\
+                ${i}\
+                @else\
+                Empty\
+                @endfor\
+                """);
         thenOutputIs("1\n1");
     }
 
@@ -483,24 +507,30 @@ public class TemplateEngineTest {
 
     @Test
     void template_content() {
-        givenTemplate("card.jte", "@param gg.jte.Content content\n" +
-                "<span>${content}</span>");
+        givenTemplate("card.jte", """
+                @param gg.jte.Content content
+                <span>${content}</span>\
+                """);
         givenTemplate("@template.card(@`<b>${model.hello}</b>`), That was a tag!");
         thenOutputIs("<span><b>Hello</b></span>, That was a tag!");
     }
 
     @Test
     void template_content_comma() {
-        givenTemplate("card.jte", "@param gg.jte.Content content\n" +
-                "<span>${content}</span>");
+        givenTemplate("card.jte", """
+                @param gg.jte.Content content
+                <span>${content}</span>\
+                """);
         givenTemplate("@template.card(@`<b>Hello, ${model.hello}</b>`), That was a tag!");
         thenOutputIs("<span><b>Hello, Hello</b></span>, That was a tag!");
     }
 
     @Test
     void templateWithGenericParam() {
-        givenTemplate("entry.jte", "@param java.util.Map.Entry<String, java.util.List<String>> entry\n" +
-                "${entry.getKey()}: ${entry.getValue().toString()}");
+        givenTemplate("entry.jte", """
+                @param java.util.Map.Entry<String, java.util.List<String>> entry
+                ${entry.getKey()}: ${entry.getValue().toString()}\
+                """);
         givenRawTemplate("""
                 @param java.util.Map<String, java.util.List<String>> map
                 @for(java.util.Map.Entry entry : map.entrySet())@template.entry(entry)
@@ -528,8 +558,10 @@ public class TemplateEngineTest {
 
     @Test
     void templateInTemplate() {
-        givenTemplate("divTwo.jte", "@param int amount\n" +
-                "Divided by two is ${amount / 2}!");
+        givenTemplate("divTwo.jte", """
+                @param int amount
+                Divided by two is ${amount / 2}!\
+                """);
         givenTemplate("card.jte", """
                 @param java.lang.String firstParam
                 @param int secondParam
@@ -540,19 +572,23 @@ public class TemplateEngineTest {
 
     @Test
     void sameTemplateReused() {
-        givenTemplate("divTwo.jte", "@param int amount\n" +
-                "${amount / 2}!");
+        givenTemplate("divTwo.jte", """
+                @param int amount
+                ${amount / 2}!\
+                """);
         givenTemplate("@template.divTwo(model.x),@template.divTwo(2 * model.x)");
         thenOutputIs("21!,42!");
     }
 
     @Test
     void templateRecursion() {
-        givenTemplate("recursion.jte", "@param int amount\n" +
-                "${amount}" +
-                "@if (amount > 0)" +
-                "@template.recursion(amount - 1)" +
-                "@endif"
+        givenTemplate("recursion.jte", """
+                @param int amount
+                ${amount}\
+                @if (amount > 0)\
+                @template.recursion(amount - 1)\
+                @endif\
+                """
         );
         givenTemplate("@template.recursion(5)");
         thenOutputIs("543210");
@@ -661,8 +697,10 @@ public class TemplateEngineTest {
     @Test
     void templateWithVarArgs1() {
         givenTemplate("varargs.jte",
-                "@param String ... values\n" +
-                        "@for(String value : values)${value} @endfor");
+                """
+                @param String ... values
+                @for(String value : values)${value} @endfor\
+                """);
         givenTemplate("@template.varargs(\"Hello\")");
         thenOutputIs("Hello ");
     }
@@ -670,8 +708,10 @@ public class TemplateEngineTest {
     @Test
     void templateWithVarArgs2() {
         givenTemplate("varargs.jte",
-                "@param String ... values\n" +
-                        "@for(String value : values)${value} @endfor");
+                """
+                @param String ... values
+                @for(String value : values)${value} @endfor\
+                """);
         givenTemplate("@template.varargs(\"Hello\", \"World\")");
         thenOutputIs("Hello World ");
     }
@@ -740,9 +780,11 @@ public class TemplateEngineTest {
 
     @Test
     void comment() {
-        givenTemplate("<%--This is a comment" +
-                " ${model.hello} everything in here is omitted--%>" +
-                "This is visible...");
+        givenTemplate("""
+                <%--This is a comment\
+                 ${model.hello} everything in here is omitted--%>\
+                This is visible...\
+                """);
         thenOutputIs("This is visible...");
     }
 
@@ -793,10 +835,14 @@ public class TemplateEngineTest {
 
     @Test
     void importInCss() {
-        givenTemplate("<style type=\"text/css\" rel=\"stylesheet\" media=\"all\">\n" +
-                "    @import url(\"https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap\"); /* <--- Right here */");
-        thenOutputIs("<style type=\"text/css\" rel=\"stylesheet\" media=\"all\">\n" +
-                "    @import url(\"https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap\"); /* <--- Right here */");
+        givenTemplate("""
+                <style type="text/css" rel="stylesheet" media="all">
+                    @import url("https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap"); /* <--- Right here */\
+                """);
+        thenOutputIs("""
+                <style type="text/css" rel="stylesheet" media="all">
+                    @import url("https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap"); /* <--- Right here */\
+                """);
     }
 
     @Test
@@ -884,22 +930,26 @@ public class TemplateEngineTest {
                         @param gg.jte.Content contentSuffix = null
                         @param gg.jte.Content footer = null
                         @template.layout.main(header = header, content = @`@if(contentPrefix != null)${contentPrefix}@endif<b>${content}</b>@if(contentSuffix != null)${contentSuffix}@endif`, footer = footer)""");
-        givenTemplate("@template.layout.mainExtended(" +
-                "header = @`" +
-                "this is the header" +
-                "`," +
-                "contentPrefix = @`" +
-                "<content-prefix>" +
-                "`," +
-                "content = @`" +
-                "this is the content" +
-                "`, " +
-                "contentSuffix=@`" +
-                "<content-suffix>" +
-                "`)");
+        givenTemplate("""
+                @template.layout.mainExtended(\
+                header = @`\
+                this is the header\
+                `,\
+                contentPrefix = @`\
+                <content-prefix>\
+                `,\
+                content = @`\
+                this is the content\
+                `, \
+                contentSuffix=@`\
+                <content-suffix>\
+                `)\
+                """);
 
-        thenOutputIs("<header>this is the header</header>" +
-                "<content><content-prefix><b>this is the content</b><content-suffix></content>");
+        thenOutputIs("""
+                <header>this is the header</header>\
+                <content><content-prefix><b>this is the content</b><content-suffix></content>\
+                """);
     }
 
     @Test
@@ -911,8 +961,10 @@ public class TemplateEngineTest {
                         @param gg.jte.Content content
                         Hello, ${content} your status is ${status}, the duration is ${duration}""");
 
-        givenTemplate("@template.layout.main(content = @`" +
-                "Sir`)");
+        givenTemplate("""
+                @template.layout.main(content = @`\
+                Sir`)\
+                """);
 
         thenOutputIs("Hello, Sir your status is 5, the duration is -1");
     }
@@ -934,8 +986,10 @@ public class TemplateEngineTest {
     @Test
     void layoutWithVarArgs() {
         givenTemplate("layout/varargs.jte",
-                "@param String ... values\n" +
-                        "@for(String value : values)${value} @endfor");
+                """
+                @param String ... values
+                @for(String value : values)${value} @endfor\
+                """);
         givenTemplate("@template.layout.varargs(\"Hello\", \"World\")");
         thenOutputIs("Hello World ");
     }
@@ -1156,9 +1210,9 @@ public class TemplateEngineTest {
     void exceptionLineNumber7() {
         givenTemplate("my/model.jte", """
                 @import gg.jte.TemplateEngineTest.Model
-                                
+                
                 @param Model model
-                                
+                
                 ${model.getThatThrows()}
                 """);
 
@@ -1172,8 +1226,10 @@ public class TemplateEngineTest {
 
     @Test
     void curlyBracesAreTracked() {
-        givenRawTemplate("!{java.util.Optional<String> name = java.util.Optional.ofNullable(null);}" +
-                "${name.map((n) -> { return \"name: \" + n; }).orElse(\"empty\")}");
+        givenRawTemplate("""
+                !{java.util.Optional<String> name = java.util.Optional.ofNullable(null);}\
+                ${name.map((n) -> { return "name: " + n; }).orElse("empty")}\
+                """);
 
         StringOutput output = new StringOutput();
         templateEngine.render(templateName, null, output);
@@ -1183,8 +1239,10 @@ public class TemplateEngineTest {
 
     @Test
     void curlyBracesAreTracked_unsafe() {
-        givenRawTemplate("!{java.util.Optional<String> name = java.util.Optional.ofNullable(null);}" +
-                "$unsafe{name.map((n) -> { return \"name: \" + n; }).orElse(\"empty\")}");
+        givenRawTemplate("""
+                !{java.util.Optional<String> name = java.util.Optional.ofNullable(null);}\
+                $unsafe{name.map((n) -> { return "name: " + n; }).orElse("empty")}\
+                """);
 
         StringOutput output = new StringOutput();
         templateEngine.render(templateName, null, output);
@@ -1194,8 +1252,10 @@ public class TemplateEngineTest {
 
     @Test
     void curlyBracesAreTracked_statement() {
-        givenRawTemplate("!{String name = java.util.Optional.ofNullable(null).map((n) -> { return \"name: \" + n; }).orElse(\"empty\");}" +
-                "${name}");
+        givenRawTemplate("""
+                !{String name = java.util.Optional.ofNullable(null).map((n) -> { return "name: " + n; }).orElse("empty");}\
+                ${name}\
+                """);
 
         StringOutput output = new StringOutput();
         templateEngine.render(templateName, null, output);
@@ -1399,8 +1459,10 @@ public class TemplateEngineTest {
 
     @Test
     void compileError6() {
-        givenTemplate("test.jte", "@param gg.jte.TemplateEngineTest.Model model\n" +
-                "test");
+        givenTemplate("test.jte", """
+                @param gg.jte.TemplateEngineTest.Model model
+                test\
+                """);
         givenTemplate("""
                 @template.test(
                 model = model,

--- a/jte/src/test/java/gg/jte/TemplateEngine_HtmlInterceptorTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngine_HtmlInterceptorTest.java
@@ -130,8 +130,10 @@ public class TemplateEngine_HtmlInterceptorTest {
 
     @Test
     void input_noAttributes() {
-        dummyCodeResolver.givenCode("page.jte", "@param String url\n" +
-                "<input>");
+        dummyCodeResolver.givenCode("page.jte", """
+                @param String url
+                <input>\
+                """);
 
         templateEngine.render("page.jte", "hello.htm", output);
 
@@ -140,8 +142,10 @@ public class TemplateEngine_HtmlInterceptorTest {
 
     @Test
     void input_withRegex() {
-        dummyCodeResolver.givenCode("page.jte", "@param String url\n" +
-                "<input required pattern=\"\\w+\">");
+        dummyCodeResolver.givenCode("page.jte", """
+                @param String url
+                <input required pattern="\\w+">\
+                """);
 
         templateEngine.render("page.jte", "hello.htm", output);
 
@@ -150,8 +154,10 @@ public class TemplateEngine_HtmlInterceptorTest {
 
     @Test
     void input_nullAttribute() {
-        dummyCodeResolver.givenCode("page.jte", "@param String css\n" +
-                "<input type=\"checkbox\" class=\"${css}\">");
+        dummyCodeResolver.givenCode("page.jte", """
+                @param String css
+                <input type="checkbox" class="${css}">\
+                """);
 
         templateEngine.render("page.jte", (String)null, output);
 
@@ -169,11 +175,13 @@ public class TemplateEngine_HtmlInterceptorTest {
 
         templateEngine.render("page.jte", "hello.htm", output);
 
-        assertThat(output.toString()).isEqualTo("<form action=\"hello.htm\" data-form=\"x\">\n" +
-                "<input name=\"param1\" disabled value=\"?\">\n" +
-                "<input name=\"param2\" value=\"?\">\n" +
-                "<input name=\"__fp\" value=\"a:hello.htm, p:param2\">\n" + // No param1 here
-                "</form>");
+        assertThat(output.toString()).isEqualTo("""
+                <form action="hello.htm" data-form="x">
+                <input name="param1" disabled value="?">
+                <input name="param2" value="?">
+                <input name="__fp" value="a:hello.htm, p:param2">
+                </form>\
+                """);
     }
 
     @Test

--- a/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngine_HtmlOutputEscapingTest.java
@@ -416,8 +416,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
         templateEngine.render("template.jte", "dummy", output);
 
-        assertThat(output.toString()).isEqualTo("<input id=\"login-email\" type=\"text\" placeholder=\"dummy\" required>\n" +
-                "<input id=\"login-password\" type=\"password\" placeholder=\"Savecode\" required>");
+        assertThat(output.toString()).isEqualTo("""
+                <input id="login-email" type="text" placeholder="dummy" required>
+                <input id="login-password" type="password" placeholder="Savecode" required>\
+                """);
     }
 
     @Test
@@ -1116,8 +1118,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
         templateEngine.render("template.jte", TemplateUtils.toMap("url", "https://jte.gg"), output);
 
-        assertThat(output.toString()).isEqualTo("\n" +
-                "<span data-content=\"&lt;a href=&#34;https://jte.gg&#34; class=&#34;foo&#34;>Hello&lt;/a>\"><a href=\"https://jte.gg\" class=\"foo\">Hello</a></span>");
+        assertThat(output.toString()).isEqualTo("""
+                
+                <span data-content="&lt;a href=&#34;https://jte.gg&#34; class=&#34;foo&#34;>Hello&lt;/a>"><a href="https://jte.gg" class="foo">Hello</a></span>\
+                """);
     }
 
     @Test
@@ -1278,8 +1282,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_notFound_noParams() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>${localizer.localize(\"unknown\")}</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>${localizer.localize("unknown")}</span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1288,8 +1294,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_notFound_withParams() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>${localizer.localize(\"unknown\", 1)}</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>${localizer.localize("unknown", 1)}</span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1298,8 +1306,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_emptyString_noParams() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>${localizer.localize(\"empty\")}</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>${localizer.localize("empty")}</span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1308,8 +1318,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_emptyString_withParams() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>${localizer.localize(\"empty\", 1)}</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>${localizer.localize("empty", 1)}</span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1318,8 +1330,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_emptyString_resultsInNullContent() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>@if(localizer.localize(\"empty\") == null)nothing is here@endif</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>@if(localizer.localize("empty") == null)nothing is here@endif</span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1328,8 +1342,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_emptyString_resultsInNullContent_withParams() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>@if(localizer.localize(\"empty\", 1) == null)nothing is here@endif</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>@if(localizer.localize("empty", 1) == null)nothing is here@endif</span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1338,8 +1354,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_noParams() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span alt=\"${localizer.localize(\"no-params\")}\">${localizer.localize(\"no-params\")}</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span alt="${localizer.localize("no-params")}">${localizer.localize("no-params")}</span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1348,8 +1366,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_html() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>${localizer.localize(\"no-params-html\")}</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>${localizer.localize("no-params-html")}</span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1394,8 +1414,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_quotesInAttribute() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span data-title=\"${localizer.localize(\"quotes\")}\"></span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span data-title="${localizer.localize("quotes")}"></span>\
+                """);
 
         templateEngine.render("template.jte", TemplateUtils.toMap("localizer", localizer), output);
 
@@ -1478,8 +1500,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_primitives() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>${localizer.localize(\"all-primitives\", false, (byte)1, (short)2, 3, 4L, 5.0f, 6.0, 'c')}</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>${localizer.localize("all-primitives", false, (byte)1, (short)2, 3, 4L, 5.0f, 6.0, 'c')}</span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1488,8 +1512,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_primitives_inAttribute() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span alt=\"${localizer.localize(\"all-primitives\", false, (byte)1, (short)2, 3, 4L, 5.0f, 6.0, 'c')}\"></span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span alt="${localizer.localize("all-primitives", false, (byte)1, (short)2, 3, 4L, 5.0f, 6.0, 'c')}"></span>\
+                """);
 
         templateEngine.render("template.jte", localizer, output);
 
@@ -1534,8 +1560,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag() {
-        codeResolver.givenCode("tag/card.jte", "@param gg.jte.Content content\n" +
-                    "<span>${content}</span>");
+        codeResolver.givenCode("tag/card.jte", """
+                    @param gg.jte.Content content
+                    <span>${content}</span>\
+                    """);
         codeResolver.givenCode("template.jte", """
                 @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
                 @param String name
@@ -1548,8 +1576,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag2() {
-        codeResolver.givenCode("tag/card.jte", "@param gg.jte.Content content\n" +
-                "<span>${content}</span>");
+        codeResolver.givenCode("tag/card.jte", """
+                @param gg.jte.Content content
+                <span>${content}</span>\
+                """);
         codeResolver.givenCode("template.jte", """
                 @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
                 @param String name
@@ -1562,8 +1592,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag3() {
-        codeResolver.givenCode("tag/card.jte", "@param gg.jte.Content content\n" +
-                "<span>${content}</span>");
+        codeResolver.givenCode("tag/card.jte", """
+                @param gg.jte.Content content
+                <span>${content}</span>\
+                """);
         codeResolver.givenCode("template.jte", """
                 @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
                 @param String name
@@ -1576,8 +1608,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag4() {
-        codeResolver.givenCode("tag/card.jte", "@param gg.jte.Content content\n" +
-                "<span>${content}</span>");
+        codeResolver.givenCode("tag/card.jte", """
+                @param gg.jte.Content content
+                <span>${content}</span>\
+                """);
         codeResolver.givenCode("template.jte", """
                 @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
                 @param String name
@@ -1590,8 +1624,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag5() {
-        codeResolver.givenCode("tag/card.jte", "@param gg.jte.Content content\n" +
-                "<span>${content}</span>");
+        codeResolver.givenCode("tag/card.jte", """
+                @param gg.jte.Content content
+                <span>${content}</span>\
+                """);
         codeResolver.givenCode("template.jte", """
                 @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
                 @param String name
@@ -1604,8 +1640,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag6() {
-        codeResolver.givenCode("tag/card.jte", "@param gg.jte.Content content\n" +
-                "<span>${content}</span>");
+        codeResolver.givenCode("tag/card.jte", """
+                @param gg.jte.Content content
+                <span>${content}</span>\
+                """);
         codeResolver.givenCode("template.jte", """
                 @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
                 @param String name
@@ -1618,8 +1656,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag7() {
-        codeResolver.givenCode("tag/card.jte", "@param gg.jte.Content content\n" +
-                "<span>${content}</span>");
+        codeResolver.givenCode("tag/card.jte", """
+                @param gg.jte.Content content
+                <span>${content}</span>\
+                """);
         codeResolver.givenCode("template.jte", """
                 @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
                 @param String name
@@ -1632,8 +1672,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_tag8() {
-        codeResolver.givenCode("tag/card.jte", "@param gg.jte.Content content = @`My default is ${42}`\n" +
-                "<span>${content}</span>");
+        codeResolver.givenCode("tag/card.jte", """
+                @param gg.jte.Content content = @`My default is ${42}`
+                <span>${content}</span>\
+                """);
         codeResolver.givenCode("template.jte", "@template.tag.card()");
 
         templateEngine.render("template.jte", TemplateUtils.toMap("localizer", localizer, "name", "<script>"), output);
@@ -1643,8 +1685,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_contentParams() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>${localizer.localize(\"link\", @`<a href=\"${\"foo\"}\">`, @`</a>`)}</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>${localizer.localize("link", @`<a href="${"foo"}">`, @`</a>`)}</span>\
+                """);
 
         templateEngine.render("template.jte", TemplateUtils.toMap("localizer", localizer), output);
 
@@ -1653,8 +1697,10 @@ public class TemplateEngine_HtmlOutputEscapingTest {
 
     @Test
     void localization_contentParams2() {
-        codeResolver.givenCode("template.jte", "@param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer\n" +
-                "<span>${localizer.localize(\"link\", @`<a style=\"color: ${\"foo\"};\">`, @`</a>`)}</span>");
+        codeResolver.givenCode("template.jte", """
+                @param gg.jte.TemplateEngine_HtmlOutputEscapingTest.MyLocalizer localizer
+                <span>${localizer.localize("link", @`<a style="color: ${"foo"};">`, @`</a>`)}</span>\
+                """);
 
         templateEngine.render("template.jte", TemplateUtils.toMap("localizer", localizer), output);
 

--- a/jte/src/test/java/gg/jte/TemplateEngine_MapParamsTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngine_MapParamsTest.java
@@ -161,8 +161,10 @@ public class TemplateEngine_MapParamsTest {
 
     @Test
     void layout_noParamsAndOneDefinition() {
-        givenLayout("page", "@param gg.jte.Content content\n" +
-                "Hello ${content}!!");
+        givenLayout("page", """
+                @param gg.jte.Content content
+                Hello ${content}!!\
+                """);
         params.put("content", (Content) output -> output.writeContent("<p>world</p>"));
 
         whenTemplateIsRendered("layout/page.jte");

--- a/jte/src/test/java/gg/jte/output/Utf8ByteOutputTest.java
+++ b/jte/src/test/java/gg/jte/output/Utf8ByteOutputTest.java
@@ -122,8 +122,10 @@ public class Utf8ByteOutputTest extends AbstractTemplateOutputTest<Utf8ByteOutpu
 
     @Test
     void utf8_japanese_katakana() {
-        String str = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム\n" +
-                "  ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン";
+        String str = """
+                イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム
+                  ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン\
+                """;
 
         output.writeContent(str);
         thenOutputIs(str);


### PR DESCRIPTION
## What?

This runs [OpenRewrite Java 17 migration recipe](https://docs.openrewrite.org/running-recipes/popular-recipe-guides/migrate-to-java-17) to adopt new/modern Java language features and APIs.

A few of the more extensive changes involve:

- Text blocks: https://openjdk.org/jeps/378
- Pattern matching: https://openjdk.org/jeps/394

## How?

I've added the plugin described in OpenRewrite docs but executed it only for projects that include `jte-parent` as a parent.