### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Documentation lives in the [jte website](https://jte.gg/).
 
 [intellij-plugin]: https://plugins.jetbrains.com/plugin/14521-jte "IntelliJ jte Plugin"
 [template-benchmark]: https://github.com/casid/template-benchmark/ "Template Benchmarks"
-[maven-central]: https://search.maven.org/artifact/gg.jte/jte "jte in Maven Central"
+[maven-central]: https://central.sonatype.com/artifact/gg.jte/jte "jte in Maven Central"

--- a/docs/index.md
+++ b/docs/index.md
@@ -281,4 +281,4 @@ This is the same benchmark as above, but the amount of threads was set to `#!jav
 
 [intellij-plugin]: https://plugins.jetbrains.com/plugin/14521-jte "IntelliJ JTE Plugin"
 [template-benchmark]: https://github.com/casid/template-benchmark/ "Template Benchmarks"
-[maven-central]: https://search.maven.org/artifact/gg.jte/jte "jte in Maven Central"
+[maven-central]: https://central.sonatype.com/artifact/gg.jte/jte "jte in Maven Central"

--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -221,6 +221,6 @@ An application jar with generated classes can be built into a native binary usin
 </plugin>
 ```
 
-[jte-maven-compiler-plugin]: https://search.maven.org/artifact/gg.jte/jte-maven-plugin
+[jte-maven-compiler-plugin]: https://central.sonatype.com/artifact/gg.jte/jte-maven-plugin
 [html-policy]: https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ latest-git-tag }}/gg.jte.runtime/gg/jte/html/HtmlPolicy.html
 [constants-package-name]: https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ latest-git-tag }}/gg/jte.runtime/gg/jte/Constants.html#PACKAGE_NAME_PRECOMPILED

--- a/jte/src/main/java/gg/jte/compiler/TemplateParser.java
+++ b/jte/src/main/java/gg/jte/compiler/TemplateParser.java
@@ -1111,7 +1111,7 @@ public final class TemplateParser {
 
     public static class HtmlTag implements gg.jte.html.HtmlTag {
 
-        // See https://www.lifewire.com/html-singleton-tags-3468620
+        // See https://developer.mozilla.org/en-US/docs/Glossary/Void_element
         private static final Set<String> VOID_HTML_TAGS = Set.of("area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr");
 
         public final String name;


### PR DESCRIPTION
## What

I noticed in #364 that the links validation workflow is broken since there are a few dead links. This fixes them.

## Broken workflow executions

- https://github.com/casid/jte/actions/runs/11000074376
- https://github.com/casid/jte/actions/runs/10530466975