### PR TITLE
Spring MVC model not forwarded #378

### DIFF
--- a/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
+++ b/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
@@ -30,7 +30,7 @@ public class JteAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(JteViewResolver.class)
     public JteViewResolver jteViewResolver(TemplateEngine templateEngine) {
-        return new JteViewResolver(templateEngine, jteProperties.getTemplateSuffix());
+        return new JteViewResolver(templateEngine, jteProperties);
     }
 
 

--- a/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
+++ b/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
@@ -7,6 +7,7 @@ public class JteProperties {
     private Boolean usePrecompiledTemplates = false;
     private String templateLocation = "src/main/jte";
     private String templateSuffix = ".jte";
+    private boolean exposeRequestAttributes = false;
 
     public String getTemplateSuffix() {
         return templateSuffix;
@@ -31,4 +32,12 @@ public class JteProperties {
     public void setUsePrecompiledTemplates(Boolean usePrecompiledTemplates) {
         this.usePrecompiledTemplates = usePrecompiledTemplates;
     }
+    
+	public boolean isExposeRequestAttributes() {
+		return exposeRequestAttributes;
+	}
+
+	public void setExposeRequestAttributes(boolean exposeRequestAttributes) {
+		this.exposeRequestAttributes = exposeRequestAttributes;
+	}
 }

--- a/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteViewResolver.java
+++ b/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteViewResolver.java
@@ -11,12 +11,13 @@ public class JteViewResolver  extends AbstractTemplateViewResolver {
 
     private final TemplateEngine templateEngine;
 
-    public JteViewResolver(TemplateEngine templateEngine, final String templateSuffix) {
+    public JteViewResolver(TemplateEngine templateEngine, JteProperties jteProperties) {
         this.templateEngine = templateEngine;
-        this.setSuffix(templateSuffix);
+        this.setSuffix(jteProperties.getTemplateSuffix());
         this.setViewClass(JteView.class);
         this.setContentType(MediaType.TEXT_HTML_VALUE);
         this.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        this.setExposeRequestAttributes(jteProperties.isExposeRequestAttributes());
     }
 
     @Override

--- a/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
+++ b/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
@@ -27,10 +27,8 @@ public class JteAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(JteViewResolver.class)
     public JteViewResolver jteViewResolver(TemplateEngine templateEngine) {
-
-        return new JteViewResolver(templateEngine, jteProperties.getTemplateSuffix());
+        return new JteViewResolver(templateEngine, jteProperties);
     }
-
 
     @Bean
     @ConditionalOnMissingBean(TemplateEngine.class)

--- a/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
+++ b/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
@@ -8,6 +8,7 @@ public class JteProperties {
     private boolean developmentMode = false;
     private String templateLocation = "src/main/jte";
     private String templateSuffix = ".jte";
+    private boolean exposeRequestAttributes = false;
 
     public String getTemplateSuffix() {
         return templateSuffix;
@@ -40,4 +41,21 @@ public class JteProperties {
     public void setDevelopmentMode(boolean developmentMode) {
         this.developmentMode = developmentMode;
     }
+
+	public boolean isUsePrecompiledTemplates() {
+		return usePrecompiledTemplates;
+	}
+
+	public void setUsePrecompiledTemplates(boolean usePrecompiledTemplates) {
+		this.usePrecompiledTemplates = usePrecompiledTemplates;
+	}
+
+	public boolean isExposeRequestAttributes() {
+		return exposeRequestAttributes;
+	}
+
+	public void setExposeRequestAttributes(boolean exposeRequestAttributes) {
+		this.exposeRequestAttributes = exposeRequestAttributes;
+	}
+    
 }

--- a/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteViewResolver.java
+++ b/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteViewResolver.java
@@ -10,12 +10,13 @@ public class JteViewResolver extends AbstractTemplateViewResolver {
 
     private final TemplateEngine templateEngine;
 
-    public JteViewResolver(TemplateEngine templateEngine, final String templateSuffix) {
+    public JteViewResolver(TemplateEngine templateEngine, JteProperties jteProperties) {
         this.templateEngine = templateEngine;
-        this.setSuffix(templateSuffix);
+        this.setSuffix(jteProperties.getTemplateSuffix());
         this.setViewClass(JteView.class);
         this.setContentType(MediaType.TEXT_HTML_VALUE);
         this.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        this.setExposeRequestAttributes(jteProperties.isExposeRequestAttributes());
     }
 
     @Override

--- a/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -30,6 +30,12 @@
       "type": "java.lang.String",
       "description": "You can configure the file suffix of jte templates the compiler resolves",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
+    },
+    {
+      "name": "gg.jte.exposeRequestAttributes",
+      "type": "java.lang.Boolean",
+      "description": "Set whether all request attributes should be added to the model prior to merging with the template",
+      "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     }
   ],
   "hints": []

--- a/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -32,7 +32,7 @@
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {
-      "name": "gg.jte.exposeRequestAttributes",
+      "name": "gg.jte.expose-request-attributes",
       "type": "java.lang.Boolean",
       "description": "Set whether all request attributes should be added to the model prior to merging with the template",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"


### PR DESCRIPTION
In order to avoid altering the current behavior, a new configuration parameter has been added:

Example:
```
gg.jte.exposeRequestAttributes=true
```

the default value is `false`

This change has been implemented in both `jte-spring-boot-starter-2` and `jte-spring-boot-starter-3`.
