### PR TITLE
Update property names to use kebab-case format and update Spring Boot version

### DIFF
--- a/jte-spring-boot-starter-2/pom.xml
+++ b/jte-spring-boot-starter-2/pom.xml
@@ -16,7 +16,7 @@
     <name>jte-spring-boot-starter-2</name>
 
     <properties>
-        <spring-boot.version>2.7.8</spring-boot.version>
+        <spring-boot.version>2.7.18</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/jte-spring-boot-starter-2/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/jte-spring-boot-starter-2/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -8,25 +8,25 @@
   ],
   "properties": [
     {
-      "name": "gg.jte.usePrecompiledTemplates",
+      "name": "gg.jte.use-precompiled-templates",
       "type": "java.lang.Boolean",
       "description": "You can precompile the templates for faster startup and rendering. To use this you need to include the Maven or Gradle Plugin: https://jte.gg/pre-compiling/",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {
-      "name": "gg.jte.developmentMode",
+      "name": "gg.jte.development-mode",
       "type": "java.lang.Boolean",
-      "description": "You can enable developmentMode so that the jte file watcher will watch for changes in templates and recompile them.",
+      "description": "You can enable development mode so that the jte file watcher will watch for changes in templates and recompile them.",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {
-      "name": "gg.jte.templateLocation",
+      "name": "gg.jte.template-location",
       "type": "java.lang.String",
       "description": "You can change the location where jte expects the templates to compile",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {
-      "name": "gg.jte.templateSuffix",
+      "name": "gg.jte.template-suffix",
       "type": "java.lang.String",
       "description": "You can configure the file suffix of jte templates the compiler resolves",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"

--- a/jte-spring-boot-starter-3/pom.xml
+++ b/jte-spring-boot-starter-3/pom.xml
@@ -16,7 +16,7 @@
     <name>jte-spring-boot-starter-3</name>
 
     <properties>
-        <spring-boot.version>3.0.2</spring-boot.version>
+        <spring-boot.version>3.3.4</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/jte-spring-boot-starter-3/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -8,25 +8,25 @@
   ],
   "properties": [
     {
-      "name": "gg.jte.usePrecompiledTemplates",
+      "name": "gg.jte.use-precompiled-templates",
       "type": "java.lang.Boolean",
       "description": "You can precompile the templates for faster startup and rendering. To use this you need to include the Maven or Gradle Plugin: https://jte.gg/pre-compiling/",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {
-      "name": "gg.jte.developmentMode",
+      "name": "gg.jte.development-mode",
       "type": "java.lang.Boolean",
-      "description": "You can enable developmentMode so that the jte file watcher will watch for changes in templates and recompile them.",
+      "description": "You can enable development mode so that the jte file watcher will watch for changes in templates and recompile them.",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {
-      "name": "gg.jte.templateLocation",
+      "name": "gg.jte.template-location",
       "type": "java.lang.String",
       "description": "You can change the location where jte expects the templates to compile",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"
     },
     {
-      "name": "gg.jte.templateSuffix",
+      "name": "gg.jte.template-suffix",
       "type": "java.lang.String",
       "description": "You can configure the file suffix of jte templates the compiler resolves",
       "sourceType": "gg.jte.springframework.boot.autoconfigure.JteProperties"


### PR DESCRIPTION
Standardize configuration property names in spring-configuration-metadata.json by converting them from camelCase to kebab-case. Also update Spring Boot version

closes #382 