### PR TITLE
Add spring-boot-starter dependency to pom.xml

### DIFF
--- a/jte-spring-boot-starter-2/pom.xml
+++ b/jte-spring-boot-starter-2/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <optional>true</optional>

--- a/jte-spring-boot-starter-3/pom.xml
+++ b/jte-spring-boot-starter-3/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <optional>true</optional>


### PR DESCRIPTION
This commit introduces the spring-boot-starter dependency to both `jte-spring-boot-starter-2/pom.xml` and `jte-spring-boot-starter-3/pom.xml`. This inclusion ensures that the necessary Spring Boot components are available for these projects, facilitating easier configuration and setup.

closes #386 