### PR TITLE
Add template change watcher for livereload

### DIFF
--- a/jte-spring-boot-starter-3/pom.xml
+++ b/jte-spring-boot-starter-3/pom.xml
@@ -51,6 +51,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <version>5.0.0</version>

--- a/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
+++ b/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
@@ -4,11 +4,18 @@ import gg.jte.CodeResolver;
 import gg.jte.ContentType;
 import gg.jte.TemplateEngine;
 import gg.jte.resolve.DirectoryCodeResolver;
+import java.io.File;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.devtools.filewatch.FileSystemWatcher;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
 
 import java.nio.file.FileSystems;
@@ -23,6 +30,9 @@ public class JteAutoConfiguration {
     public JteAutoConfiguration(JteProperties jteProperties) {
         this.jteProperties = jteProperties;
     }
+
+
+    Logger logger = LoggerFactory.getLogger(JteAutoConfiguration.class);
 
     @Bean
     @ConditionalOnMissingBean(JteViewResolver.class)
@@ -48,5 +58,22 @@ public class JteAutoConfiguration {
             return TemplateEngine.create(codeResolver, Paths.get("jte-classes"), ContentType.Html, getClass().getClassLoader());
         }
         throw new JteConfigurationException("You need to either set gg.jte.usePrecompiledTemplates or gg.jte.developmentMode to true ");
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "gg.jte.developmentMode", havingValue = "true")
+    FileSystemWatcher viewComponentFileSystemWatcher(ApplicationContext applicationContext, JteProperties jteProperties) {
+        var fileSystemWatcher = new FileSystemWatcher();
+        File jteDir = new File(jteProperties.getTemplateLocation());
+        fileSystemWatcher.addSourceDirectory(jteDir);
+        logger.info("Watching for template changes at: {}", jteDir.getAbsoluteFile().getPath());
+        fileSystemWatcher.addListener(
+            changeSet -> {
+                logger.debug("Detected change to template: {}", changeSet);
+                applicationContext.publishEvent(new ContextRefreshedEvent(applicationContext));
+            }
+        );
+        fileSystemWatcher.start();
+        return fileSystemWatcher;
     }
 }


### PR DESCRIPTION
Include Spring Boot DevTools dependency for improved development experience. Implement a file system watcher to detect template changes and refresh the application context automatically in development mode, to trigger a live reload.