### PR TITLE
Fix compilation in module enabled applications

### DIFF
--- a/jte/src/main/java/gg/jte/compiler/ClassUtils.java
+++ b/jte/src/main/java/gg/jte/compiler/ClassUtils.java
@@ -33,6 +33,14 @@ public final class ClassUtils {
                 pathConsumer.accept(path);
             }
         }
+        String modulePath = System.getProperty("jdk.module.path");
+
+        if (!StringUtils.isBlank(modulePath)) {
+            String[] paths = modulePath.split(separator);
+            for (String path : paths) {
+                pathConsumer.accept(path);
+            }
+        }
 
         if (classLoader instanceof URLClassLoader loader) {
             for (URL url : loader.getURLs()) {


### PR DESCRIPTION
Currently it is difficult to use JTE in modularized applications because the compiler does not add modules to class path, so you get class not found issues. This PR simply adds the module path to the class path, which fixes this issue.