### PR TITLE
Java compiler error matching

### DIFF
--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -31,6 +31,13 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void helloWorldWithDeprecatedMethodCall() {
+        givenRawTemplate("@param gg.jte.TemplateEngineTest.Model model\n${model.getAnotherWorld()} ${model.deprecatedMethod()}");
+        thenOutputIs("Another World true");
+    }
+
+
+    @Test
     void templateWithoutParameters() {
         givenRawTemplate("Hello World!");
         thenOutputIs("Hello World!");
@@ -1579,6 +1586,8 @@ public class TemplateEngineTest {
         Throwable throwable = catchThrowable(() -> thenOutputIs("ignored"));
         return assertThat(throwable).isInstanceOf(TemplateException.class);
     }
+
+
 
     @SuppressWarnings("SameParameterValue")
     private void thenRenderingFailsWithExceptionCausedBy(Class<? extends Throwable> clazz) {

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -1472,6 +1472,17 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void compileErrorWithWarning() {
+        givenTemplate("test.jte", "@param gg.jte.TemplateEngineTest.Model model\n${model.deprecatedMethod()}\nThis will not compile!\n${model.helloUnknown}\n!!");
+        givenTemplate("@template.test(model)");
+        thenRenderingFailsWithException()
+                .hasMessageStartingWith("Failed to compile template, error at test.jte:4\n")
+                .hasMessageContaining("cannot find symbol")
+                .hasMessageContaining("model.helloUnknown")
+                .hasMessageContaining("has been deprecated");
+    }
+
+    @Test
     void calledWithWrongParam1() {
         givenRawTemplate("@param String hello\n${hello}");
         thenRenderingFailsWithException().hasMessage("Failed to render test/template.jte, type mismatch for parameter: Expected java.lang.String, got gg.jte.TemplateEngineTest$Model");
@@ -1624,5 +1635,8 @@ public class TemplateEngineTest {
         public String getThatThrows() {
             throw new NullPointerException("Oops");
         }
+
+        @Deprecated(forRemoval = true)
+        public boolean deprecatedMethod() { return true; }
     }
 }


### PR DESCRIPTION
When compiling a template containing a mix of warnings and errors the first warning/error will be matched by `getErrorMessage` which might not be the desired error message.
This leads to a misleading TemplateException like

```
10:32:17,860 ERROR Failed to execute goal gg.jte:jte-maven-plugin:3.1.13:precompile (web-templates) on project example: Execution web-templates of goal gg.jte:jte-maven-plugin:3.1.13:precompile failed: Failed to compile template, error at some/file/with/warning.jte:35
```
with the culprit buried deeper inside the log.

This proposed change will only match messages of the type 'error' and therefore shows the message responsible for the failed compilation on top.