### PR TITLE
Add some more config properties to jte-models.

### DIFF
--- a/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
@@ -19,6 +19,14 @@ public class ModelConfig {
         return map.getOrDefault("implementationAnnotation", "");
     }
 
+    public String staticImplementationAnnotation() {
+        return map.getOrDefault("staticImplementationAnnotation", "");
+    }
+
+    public String dynamicImplementationAnnotation() {
+        return map.getOrDefault("dynamicImplementationAnnotation", "");
+    }
+
     public Language language() {
         String configuredLanguage = map.getOrDefault("language", "Java");
         try {
@@ -46,5 +54,9 @@ public class ModelConfig {
             return null;
         }
         return Pattern.compile(excludePattern);
+    }
+
+    public String interfaceName() {
+        return map.getOrDefault("interfaceName", "Templates");
     }
 }

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelExtension.java
@@ -43,10 +43,11 @@ public class ModelExtension implements JteExtension {
                 .filter(x -> excludePattern == null || !excludePattern.matcher(x.fullyQualifiedClassName()).matches()) //
                 .collect(Collectors.toSet());
 
+        var interfaceName = modelConfig.interfaceName();
         return Stream.of(
-                new ModelGenerator(engine, "interfacetemplates", "Templates", "Templates", language),
-                new ModelGenerator(engine, "statictemplates", "StaticTemplates", "Templates", language),
-                new ModelGenerator(engine, "dynamictemplates", "DynamicTemplates", "Templates", language)
+                new ModelGenerator(engine, "interfacetemplates", interfaceName, interfaceName, language),
+                new ModelGenerator(engine, "statictemplates", "Static" + interfaceName, interfaceName, language),
+                new ModelGenerator(engine, "dynamictemplates", "Dynamic" + interfaceName, interfaceName, language)
         ).map(g -> g.generate(config, templateDescriptionsFiltered, modelConfig))
                 .toList();
     }

--- a/jte-models/src/main/java/gg/jte/models/generator/SquashBlanksOutput.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/SquashBlanksOutput.java
@@ -11,7 +11,7 @@ public class SquashBlanksOutput implements TemplateOutput {
 
     @Override
     public void writeContent(String value) {
-        if (value.contains("\n") && value.trim().isEmpty()) {
+        if (value.contains("\n") && value.isBlank()) {
             return;
         }
         delegate.writeContent(value);

--- a/jte-models/src/main/jte/dynamictemplates/kmain.jte
+++ b/jte-models/src/main/jte/dynamictemplates/kmain.jte
@@ -18,6 +18,7 @@ import ${imp}
 @endfor
 
 ${modelConfig.implementationAnnotation()}
+${modelConfig.dynamicImplementationAnnotation()}
 class ${targetClassName}(private val engine: TemplateEngine) : ${interfaceName} {
     @for(TemplateDescription template: templates)
         @template.dynamictemplates.kmethod(template = template)

--- a/jte-models/src/main/jte/dynamictemplates/main.jte
+++ b/jte-models/src/main/jte/dynamictemplates/main.jte
@@ -21,10 +21,11 @@ import gg.jte.models.runtime.*;
 @endfor
 
 ${modelConfig.implementationAnnotation()}
+${modelConfig.dynamicImplementationAnnotation()}
 public class ${targetClassName} implements ${interfaceName} {
     private final TemplateEngine engine;
 
-    public DynamicTemplates(TemplateEngine engine) {
+    public ${targetClassName}(TemplateEngine engine) {
         this.engine = engine;
     }
 

--- a/jte-models/src/main/jte/statictemplates/kmain.jte
+++ b/jte-models/src/main/jte/statictemplates/kmain.jte
@@ -20,6 +20,7 @@ import ${imp}
 @endfor
 
 ${modelConfig.implementationAnnotation()}
+${modelConfig.staticImplementationAnnotation()}
 class ${targetClassName} : ${interfaceName} {
     @for(TemplateDescription template: templates)
         @template.statictemplates.kmethod(config = config, template = template)

--- a/jte-models/src/main/jte/statictemplates/main.jte
+++ b/jte-models/src/main/jte/statictemplates/main.jte
@@ -21,6 +21,7 @@ import gg.jte.html.HtmlTemplateOutput;
 @endfor
 
 ${modelConfig.implementationAnnotation()}
+${modelConfig.staticImplementationAnnotation()}
 public class ${targetClassName} implements ${interfaceName} {
     @for(TemplateDescription template: templates)
         @template.statictemplates.method(config = config, template = template)

--- a/test/jte-runtime-cp-test-models-gradle/build.gradle
+++ b/test/jte-runtime-cp-test-models-gradle/build.gradle
@@ -31,7 +31,10 @@ jte {
     generate()
     binaryStaticContent = true
     jteExtension('gg.jte.models.generator.ModelExtension') {
-        implementationAnnotation = '@test.Dummy'
+        interfaceName = 'HtmlTemplates'
+        implementationAnnotation = '@test.Singleton'
+        staticImplementationAnnotation = '@test.Secondary'
+        dynamicImplementationAnnotation = '@test.Requires(bean = TemplateEngine.class)'
         includePattern = '.*'
         excludePattern = '.*Excluded.*'
     }

--- a/test/jte-runtime-cp-test-models-gradle/src/main/java/test/Requires.java
+++ b/test/jte-runtime-cp-test-models-gradle/src/main/java/test/Requires.java
@@ -6,8 +6,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation for a pretend DI framework.
+ */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface Dummy {
+public @interface Requires {
+    Class<?> bean();
 }

--- a/test/jte-runtime-cp-test-models-gradle/src/main/java/test/Secondary.java
+++ b/test/jte-runtime-cp-test-models-gradle/src/main/java/test/Secondary.java
@@ -1,0 +1,16 @@
+package test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for a pretend DI framework.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Secondary {
+}

--- a/test/jte-runtime-cp-test-models-gradle/src/main/java/test/Singleton.java
+++ b/test/jte-runtime-cp-test-models-gradle/src/main/java/test/Singleton.java
@@ -1,0 +1,16 @@
+package test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for a pretend DI framework.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Singleton {
+}


### PR DESCRIPTION
Most importantly, allows you to change the name of the generated interface, which was previously hard-coded as `Templates`.

"staticImplementationAnnotation" and "dynamicImplementationAnnotation" allow adding suitable annotations to use with a dependency injection framework.