### PR TITLE
Mention Noticeable Newspages proudly rendered using JTE

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Documentation lives in the [jte website](https://jte.gg/).
 - [Mazebert TD (game website)](https://mazebert.com)
 - [Javalin website example with login and multiple languages](https://github.com/casid/jte-javalin-tutorial)
 - [FlowCrypt Admin Panel](https://flowcrypt.com/docs/technical/enterprise-admin-panel/usage/ui-overview.html)
+- [Noticeable Newspages](https://noticeable.io)
 
 [intellij-plugin]: https://plugins.jetbrains.com/plugin/14521-jte "IntelliJ jte Plugin"
 [template-benchmark]: https://github.com/casid/template-benchmark/ "Template Benchmarks"


### PR DESCRIPTION
I’m a big fan of JTE. I recently migrated the Noticeable Newspages of my small project from Soy Sauce (Google Closure Templates) to JTE, and the experience has been a clear improvement across the board.

Since there are a few mentions already, I’ve prepared this PR in case you're open to adding that Noticeable Newspages are proudly rendered with JTE.