### PR TITLE
added trimControlStructures property configuration option to spring boot starters

### DIFF
--- a/docs/spring-boot-starter-3.md
+++ b/docs/spring-boot-starter-3.md
@@ -78,6 +78,12 @@ If you set `developmentMode = true` the jte [file watcher](hot-reloading.md) wil
 gg.jte.developmentMode=true
 ```
 
+In development mode, you can also set `trimControlStructures = true` which will trim control structures.
+
+```properties linenums="1"
+gg.jte.trimControlStructures=true
+```
+
 ### Production
 
 To use [precompiled Templates](pre-compiling.md) in production, for use with a JRE environment, you need to configure the Maven/Gradle Plugin to precompile your templates:

--- a/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
+++ b/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
@@ -48,6 +48,7 @@ public class JteAutoConfiguration {
             CodeResolver codeResolver = new DirectoryCodeResolver(FileSystems.getDefault().getPath("", split));
             TemplateEngine templateEngine = TemplateEngine.create(codeResolver, Paths.get("jte-classes"), ContentType.Html, getClass().getClassLoader());
             templateEngine.setBinaryStaticContent(true);
+            templateEngine.setTrimControlStructures(jteProperties.isTrimControlStructures());
             return templateEngine;
         }
 

--- a/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
+++ b/jte-spring-boot-starter-2/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
@@ -25,6 +25,11 @@ public class JteProperties {
      */
     private boolean exposeRequestAttributes = false;
 
+    /**
+     * Set whether to trim control structures, resulting in prettier output.
+     */
+    private boolean trimControlStructures = false;
+
     public String getTemplateSuffix() {
         return templateSuffix;
     }
@@ -56,4 +61,12 @@ public class JteProperties {
 	public void setExposeRequestAttributes(boolean exposeRequestAttributes) {
 		this.exposeRequestAttributes = exposeRequestAttributes;
 	}
+
+    public boolean isTrimControlStructures() {
+        return trimControlStructures;
+    }
+
+    public void setTrimControlStructures(boolean trimControlStructures) {
+        this.trimControlStructures = trimControlStructures;
+    }
 }

--- a/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
+++ b/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
@@ -45,7 +45,9 @@ public class JteAutoConfiguration {
             // If using IntelliJ, use Ctrl-F9 to trigger an auto-refresh when editing non-jte files.
             String[] split = jteProperties.getTemplateLocation().split("/");
             CodeResolver codeResolver = new DirectoryCodeResolver(FileSystems.getDefault().getPath("", split));
-            return TemplateEngine.create(codeResolver, Paths.get("jte-classes"), ContentType.Html, getClass().getClassLoader());
+            TemplateEngine templateEngine = TemplateEngine.create(codeResolver, Paths.get("jte-classes"), ContentType.Html, getClass().getClassLoader());
+            templateEngine.setTrimControlStructures(jteProperties.isTrimControlStructures());
+            return templateEngine;
         }
         throw new JteConfigurationException("You need to either set gg.jte.usePrecompiledTemplates or gg.jte.developmentMode to true ");
     }

--- a/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
+++ b/jte-spring-boot-starter-3/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
@@ -31,6 +31,11 @@ public class JteProperties {
      */
     private boolean exposeRequestAttributes = false;
 
+    /**
+     * Set whether to trim control structures, resulting in prettier output.
+     */
+    private boolean trimControlStructures = false;
+
     public String getTemplateSuffix() {
         return templateSuffix;
     }
@@ -78,5 +83,12 @@ public class JteProperties {
 	public void setExposeRequestAttributes(boolean exposeRequestAttributes) {
 		this.exposeRequestAttributes = exposeRequestAttributes;
 	}
-    
+
+    public boolean isTrimControlStructures() {
+        return trimControlStructures;
+    }
+
+    public void setTrimControlStructures(boolean trimControlStructures) {
+        this.trimControlStructures = trimControlStructures;
+    }
 }


### PR DESCRIPTION
This PR changes the spring boot starters so that if you are using them in development mode, you can now set the property to trim control structures to remove the whitespace.  This enables you to produce the same output as seen in production if you are using the `trimControlStructures` option in the maven/gradle plugins to generate production templates.  Also useful when writing unit tests for a rendered template so you don't have to cater for whitespace when asserting output.