### PR TITLE
Add Demeter Car website to JTE users list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Documentation lives in the [jte website](https://jte.gg/).
 - [Javalin website example with login and multiple languages](https://github.com/casid/jte-javalin-tutorial)
 - [FlowCrypt Admin Panel](https://flowcrypt.com/docs/technical/enterprise-admin-panel/usage/ui-overview.html)
 - [Noticeable Newspages](https://noticeable.io)
+- [Demeter Car Rental](https://www.demetercar.de)
 
 [intellij-plugin]: https://plugins.jetbrains.com/plugin/14521-jte "IntelliJ jte Plugin"
 [template-benchmark]: https://github.com/casid/template-benchmark/ "Template Benchmarks"


### PR DESCRIPTION
This PR adds [demetercar.de](https://www.demetercar.de) to the **Websites rendered with JTE** section.

The website has been built with Spring Boot, Kotlin, and JTE, and has been running in production for over a year.

Thanks for maintaining JTE. It has been a great experience to use it in a real-world project.

<img width="885" height="509" alt="image" src="https://github.com/user-attachments/assets/59c1ee9f-27f8-4982-978c-b586a80bf562" />
