### PR TITLE
Make generated Kotlin classes internal

### DIFF
--- a/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
+++ b/jte-kotlin/src/main/java/gg/jte/compiler/kotlin/KotlinCodeGenerator.java
@@ -87,7 +87,7 @@ public class KotlinCodeGenerator implements CodeGenerator {
 
     private void writeClass() {
         kotlinCode.append("@Suppress(\"UNCHECKED_CAST\", \"UNUSED_PARAMETER\")").append('\n');
-        kotlinCode.append("class ").append(classInfo.className).append(" {\n");
+        kotlinCode.append("internal class ").append(classInfo.className).append(" {\n");
         kotlinCode.append("companion object {\n");
         fieldsMarker = kotlinCode.getMarkerOfCurrentPosition();
         kotlinCode.append("\t@JvmStatic fun render(");


### PR DESCRIPTION
There are two reasons for this. The first is that there's no reason for these to be public. They are consumed entirely in the current compilation unit, and there's no reason for external code to ever reference these. This comes up when working in a large Spring/Micronaut project where smaller modules act as libraries to a final aggregate.

The other reason to do this is that by making this classes public, it prevents them from being used with data classes that the developer declared as internal. The compiler will complain that the generated code exposes an internal class in a public API.