### PR TITLE
Fix variadic parameter parsing

### DIFF
--- a/jte/src/main/java/gg/jte/compiler/java/JavaParamInfo.java
+++ b/jte/src/main/java/gg/jte/compiler/java/JavaParamInfo.java
@@ -8,15 +8,10 @@ public class JavaParamInfo {
         String type;
         String name;
         String defaultValue;
-        boolean varargs;
 
-        int typeStartIndex = -1;
-        int typeEndIndex = -1;
-        int nameStartIndex = -1;
         int nameEndIndex = -1;
         int defaultValueStartIndex = -1;
         int genericDepth = 0;
-        int varArgsIndex = parameterString.indexOf("...");
         for (int i = 0; i < parameterString.length(); ++i) {
             char character = parameterString.charAt(i);
 
@@ -30,22 +25,9 @@ public class JavaParamInfo {
                 continue;
             }
 
-            if (typeStartIndex == -1) {
-                if (!Character.isWhitespace(character)) {
-                    typeStartIndex = i;
-                }
-            } else if (typeEndIndex == -1) {
-                if (Character.isWhitespace(character) && i > varArgsIndex) {
-                    typeEndIndex = i;
-                }
-            } else if (nameStartIndex == -1) {
-                if (!Character.isWhitespace(character)) {
-                    nameStartIndex = i;
-                }
-            } else if (nameEndIndex == -1) {
-                if (Character.isWhitespace(character) || character == '=') {
-                    nameEndIndex = i;
-                    i += 1;
+            if (nameEndIndex == -1) {
+                if (character == '=') {
+                    nameEndIndex = i - 1;
                 }
             } else if (defaultValueStartIndex == -1) {
                 if (!Character.isWhitespace(character)) {
@@ -54,21 +36,30 @@ public class JavaParamInfo {
             }
         }
 
-        if (typeStartIndex == -1 || typeEndIndex == -1) {
-            type = "";
-        } else {
-            type = parameterString.substring(typeStartIndex, typeEndIndex);
-        }
-
         if (nameEndIndex == -1) {
-            nameEndIndex = parameterString.length();
+            nameEndIndex = parameterString.length() - 1;
         }
 
-        if (nameStartIndex == -1) {
+        int typeNameSeparator = -1;
+        for (int i = nameEndIndex; i >= 0; --i) {
+            char character = parameterString.charAt(i);
+
+            if (Character.isWhitespace(character)) {
+                if (i == nameEndIndex) {
+                    --nameEndIndex; // trailing name whitespace
+                } else {
+                    typeNameSeparator = i;
+                    break;
+                }
+            }
+        }
+
+        if (typeNameSeparator == -1) {
             visitor.onError("Missing parameter name: '@param " + parameterString + "'");
         }
 
-        name = parameterString.substring(nameStartIndex, nameEndIndex);
+        type = parameterString.substring(0, typeNameSeparator);
+        name = parameterString.substring(typeNameSeparator + 1, nameEndIndex + 1);
 
         if (defaultValueStartIndex == -1) {
             defaultValue = null;
@@ -76,8 +67,6 @@ public class JavaParamInfo {
             defaultValue = parameterString.substring(defaultValueStartIndex);
         }
 
-        varargs = varArgsIndex != -1;
-
-        return new ParamInfo(type, name, defaultValue, varargs, templateLine);
+        return new ParamInfo(type, name, defaultValue, type.contains("..."), templateLine);
     }
 }

--- a/jte/src/main/java/gg/jte/compiler/java/JavaParamInfo.java
+++ b/jte/src/main/java/gg/jte/compiler/java/JavaParamInfo.java
@@ -12,8 +12,29 @@ public class JavaParamInfo {
         int nameEndIndex = -1;
         int defaultValueStartIndex = -1;
         int genericDepth = 0;
+
+        boolean stringMode = false;
         for (int i = 0; i < parameterString.length(); ++i) {
             char character = parameterString.charAt(i);
+
+            if (character == '"') {
+                if (stringMode) {
+                    int escapeCount = 0;
+                    while (parameterString.charAt(i - escapeCount - 1) == '\\') {
+                        ++escapeCount;
+                    }
+
+                    if (escapeCount % 2 == 0) {
+                        stringMode = false;
+                    }
+                } else {
+                    stringMode = true;
+                }
+            }
+
+            if (stringMode) {
+                continue;
+            }
 
             if (character == '<') {
                 ++genericDepth;
@@ -25,14 +46,16 @@ public class JavaParamInfo {
                 continue;
             }
 
-            if (nameEndIndex == -1) {
-                if (character == '=') {
-                    nameEndIndex = i - 1;
+            if (character == '=') {
+                nameEndIndex = i - 1;
+
+                while (Character.isWhitespace(character)) {
+                    ++i;
+                    character = parameterString.charAt(i);
                 }
-            } else if (defaultValueStartIndex == -1) {
-                if (!Character.isWhitespace(character)) {
-                    defaultValueStartIndex = i;
-                }
+
+                defaultValueStartIndex = i + 1;
+                break;
             }
         }
 

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -821,6 +821,14 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void variadic_issue493() { // https://github.com/casid/jte/issues/493
+        givenRawTemplate("@param String model = \"Loading...\"\n${model}");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
     void commentBeforeParams() {
         givenRawTemplate("<%--This is a comment--%>@param gg.jte.TemplateEngineTest.Model model\n" + "!{model.setX(12);}${model.x}");
         thenOutputIs("12");

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -805,6 +805,22 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void variadic() {
+        givenRawTemplate("@param String... models\n${models[0]}");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, new String[] { "test value" }, output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void variadic_annotation() {
+        givenRawTemplate("@param String @gg.jte.TestUtils.TypeUseAnnotation ... models\n${models[0]}");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, new String[] { "test value" }, output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
     void commentBeforeParams() {
         givenRawTemplate("<%--This is a comment--%>@param gg.jte.TemplateEngineTest.Model model\n" + "!{model.setX(12);}${model.x}");
         thenOutputIs("12");

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -821,6 +821,30 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void variadic_annotationParam() {
+        givenRawTemplate("@param String @gg.jte.TestUtils.TypeUseAnnotationParam(\"=\") ... models\n${models[0]}");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, new String[] { "test value" }, output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void variadic_annotationParamEscape() {
+        givenRawTemplate("@param String @gg.jte.TestUtils.TypeUseAnnotationParam(\"\\\"\") ... models\n${models[0]}");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, new String[] { "test value" }, output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void variadic_annotationParamEscapeDouble() {
+        givenRawTemplate("@param String @gg.jte.TestUtils.TypeUseAnnotationParam(\"\\\\\") ... models\n${models[0]}");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, new String[] { "test value" }, output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
     void variadic_issue493() { // https://github.com/casid/jte/issues/493
         givenRawTemplate("@param String model = \"Loading...\"\n${model}");
         StringOutput output = new StringOutput();

--- a/jte/src/test/java/gg/jte/TestUtils.java
+++ b/jte/src/test/java/gg/jte/TestUtils.java
@@ -18,4 +18,11 @@ public class TestUtils {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface TypeUseAnnotation {
     }
+
+    @SuppressWarnings("unused") // see e.g. gg.jte.TemplateEngineTest.variadic_annotation
+    @Target({ElementType.TYPE_USE})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TypeUseAnnotationParam {
+        String value();
+    }
 }

--- a/jte/src/test/java/gg/jte/TestUtils.java
+++ b/jte/src/test/java/gg/jte/TestUtils.java
@@ -1,10 +1,21 @@
 package gg.jte;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 public class TestUtils {
 
     private static final double JAVA_VERSION = Double.parseDouble(System.getProperty("java.specification.version", "0"));
 
     public static boolean isInstanceOfPatternMatchingJavaVersion() {
         return JAVA_VERSION >= 14; // Not really needed since we compile with jdk 17, but leave as pattern for the next Java version features.
+    }
+
+    @SuppressWarnings("unused") // see e.g. gg.jte.TemplateEngineTest.variadic_annotation
+    @Target({ElementType.TYPE_USE})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TypeUseAnnotation {
     }
 }


### PR DESCRIPTION
Alternative to #524.

~~This will still fail to parse complex annotations such as `@Foo(value = "bar")`.~~