### PR TITLE
Add `@javax.annotation.processing.Generated` annotation to generated Java source code files

### DIFF
--- a/jte-models/src/main/jte/dynamictemplates/main.jte
+++ b/jte-models/src/main/jte/dynamictemplates/main.jte
@@ -22,6 +22,7 @@ import gg.jte.models.runtime.*;
 
 ${modelConfig.implementationAnnotation()}
 ${modelConfig.dynamicImplementationAnnotation()}
+@javax.annotation.processing.Generated("gg.jte.TemplateEngine")
 public class ${targetClassName} implements ${interfaceName} {
     private final TemplateEngine engine;
 

--- a/jte-models/src/main/jte/interfacetemplates/main.jte
+++ b/jte-models/src/main/jte/interfacetemplates/main.jte
@@ -15,6 +15,7 @@ import ${imp};
 @endfor
 
 ${modelConfig.interfaceAnnotation()}
+@javax.annotation.processing.Generated("gg.jte.TemplateEngine")
 public interface ${targetClassName} {
     @for(TemplateDescription template: templates)
         @template.interfacetemplates.method(template = template)

--- a/jte-models/src/main/jte/statictemplates/main.jte
+++ b/jte-models/src/main/jte/statictemplates/main.jte
@@ -22,6 +22,7 @@ import gg.jte.html.HtmlTemplateOutput;
 
 ${modelConfig.implementationAnnotation()}
 ${modelConfig.staticImplementationAnnotation()}
+@javax.annotation.processing.Generated("gg.jte.TemplateEngine")
 public class ${targetClassName} implements ${interfaceName} {
     @for(TemplateDescription template: templates)
         @template.statictemplates.method(config = config, template = template)

--- a/jte/src/main/java/gg/jte/compiler/java/JavaCodeGenerator.java
+++ b/jte/src/main/java/gg/jte/compiler/java/JavaCodeGenerator.java
@@ -74,6 +74,7 @@ public class JavaCodeGenerator implements CodeGenerator {
 
     private void writeClass() {
         javaCode.append("@SuppressWarnings(\"unchecked\")\n");
+        javaCode.append("@javax.annotation.processing.Generated(\"gg.jte.TemplateEngine\")\n");
         javaCode.append("public final class ").append(classInfo.className).append(" {\n");
         fieldsMarker = javaCode.getMarkerOfCurrentPosition();
         javaCode.append("\tpublic static void render(");


### PR DESCRIPTION
Generated code should be annotated with `@javax.annotation.processing.Generated` so that static analysis tools like [Error Prone](https://errorprone.info) can ignore generated code.