### PR TITLE
Add `staticImplementationSingleton` feature to `jte-models`

### DIFF
--- a/docs/gradle-plugin.md
+++ b/docs/gradle-plugin.md
@@ -143,16 +143,17 @@ See details about it in the [jte-models documentation](jte-models.md).
 
 The following parameters are available for this extension:
 
-| Parameter                         | Description                                                                                                                                                                                                 | Default |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `interfaceAnnotation`             | The FQCN of the annotation to add to the generated interface                                                                                                                                                | None    |
-| `implementationAnnotation`        | The FQCN of the annotation to add to the generated implementation classes                                                                                                                                   | None    |
-| `staticImplementationAnnotation`  | The FQCN of the annotation to add to the generated static implementation classes                                                                                                                            | None    |
-| `dynamicImplementationAnnotation` | The FQCN of the annotation to add to the generated dynamic implementation classes                                                                                                                           | None    |
-| `staticImplementationSingleton`   | For `Java`, the field name of the singleton instance to add to the generated static implementation class. For `Kotlin`, `true` to use `object` instead of `class` for generated static implementation class | None    |
-| `language`                        | The target language for the generated classes. Either `Java` or `Kotlin`                                                                                                                                    | `Java`  |
-| `includePattern`                  | A regular expression to only include certain templates                                                                                                                                                      | None    |
-| `excludePattern`                  | A regular expression to exclude certain templates                                                                                                                                                           | None    |
+| Parameter                         | Description                                                                                                                                                            | Default     |
+|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| `interfaceAnnotation`             | The FQCN of the annotation to add to the generated interface                                                                                                           | None        |
+| `implementationAnnotation`        | The FQCN of the annotation to add to the generated implementation classes                                                                                              | None        |
+| `staticImplementationAnnotation`  | The FQCN of the annotation to add to the generated static implementation classes                                                                                       | None        |
+| `dynamicImplementationAnnotation` | The FQCN of the annotation to add to the generated dynamic implementation classes                                                                                      | None        |
+| `staticImplementationSingleton`   | For the generated static implementation classes, `Java` will provide a static wrapper class for a singleton instance and `Kotlin` will use `object` instead of `class` | `true`      |
+| `language`                        | The target language for the generated classes. Either `Java` or `Kotlin`                                                                                               | `Java`      |
+| `includePattern`                  | A regular expression to only include certain templates                                                                                                                 | None        |
+| `excludePattern`                  | A regular expression to exclude certain templates                                                                                                                      | None        |
+| `interfaceName`                   | The name of the interface                                                                                                                                              | `Templates` |
 
 ##### Example { #model-extension-example }
 

--- a/docs/gradle-plugin.md
+++ b/docs/gradle-plugin.md
@@ -143,13 +143,16 @@ See details about it in the [jte-models documentation](jte-models.md).
 
 The following parameters are available for this extension:
 
-| Parameter                  | Description                                                               | Default |
-|----------------------------|---------------------------------------------------------------------------|---------|
-| `interfaceAnnotation`      | The FQCN of the annotation to add to the generated interface              | None    |
-| `implementationAnnotation` | The FQCN of the annotation to add to the generated implementation classes | None    |
-| `language`                 | The target language for the generated classes. Either `Java` or `Kotlin`  | `Java`  |
-| `includePattern`           | A regular expression to only include certain templates                    | None    |
-| `excludePattern`           | A regular expression to exclude certain templates                         | None    |
+| Parameter                         | Description                                                                                                                                                                                                 | Default |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `interfaceAnnotation`             | The FQCN of the annotation to add to the generated interface                                                                                                                                                | None    |
+| `implementationAnnotation`        | The FQCN of the annotation to add to the generated implementation classes                                                                                                                                   | None    |
+| `staticImplementationAnnotation`  | The FQCN of the annotation to add to the generated static implementation classes                                                                                                                            | None    |
+| `dynamicImplementationAnnotation` | The FQCN of the annotation to add to the generated dynamic implementation classes                                                                                                                           | None    |
+| `staticImplementationSingleton`   | For `Java`, the field name of the singleton instance to add to the generated static implementation class. For `Kotlin`, `true` to use `object` instead of `class` for generated static implementation class | None    |
+| `language`                        | The target language for the generated classes. Either `Java` or `Kotlin`                                                                                                                                    | `Java`  |
+| `includePattern`                  | A regular expression to only include certain templates                                                                                                                                                      | None    |
+| `excludePattern`                  | A regular expression to exclude certain templates                                                                                                                                                           | None    |
 
 ##### Example { #model-extension-example }
 

--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -144,16 +144,17 @@ See details about it in the [jte-models documentation](jte-models.md).
 
 The following parameters are available for this extension:
 
-| Parameter                         | Description                                                                                                                                                                                                 | Default |
-|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `interfaceAnnotation`             | The FQCN of the annotation to add to the generated interface                                                                                                                                                | None    |
-| `implementationAnnotation`        | The FQCN of the annotation to add to the generated implementation classes                                                                                                                                   | None    |
-| `staticImplementationAnnotation`  | The FQCN of the annotation to add to the generated static implementation classes                                                                                                                            | None    |
-| `dynamicImplementationAnnotation` | The FQCN of the annotation to add to the generated dynamic implementation classes                                                                                                                           | None    |
-| `staticImplementationSingleton`   | For `Java`, the field name of the singleton instance to add to the generated static implementation class. For `Kotlin`, `true` to use `object` instead of `class` for generated static implementation class | None    |
-| `language`                        | The target language for the generated classes. Either `Java` or `Kotlin`                                                                                                                                    | `Java`  |
-| `includePattern`                  | A regular expression to only include certain templates                                                                                                                                                      | None    |
-| `excludePattern`                  | A regular expression to exclude certain templates                                                                                                                                                           | None    |
+| Parameter                         | Description                                                                                                                                                            | Default     |
+|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| `interfaceAnnotation`             | The FQCN of the annotation to add to the generated interface                                                                                                           | None        |
+| `implementationAnnotation`        | The FQCN of the annotation to add to the generated implementation classes                                                                                              | None        |
+| `staticImplementationAnnotation`  | The FQCN of the annotation to add to the generated static implementation classes                                                                                       | None        |
+| `dynamicImplementationAnnotation` | The FQCN of the annotation to add to the generated dynamic implementation classes                                                                                      | None        |
+| `staticImplementationSingleton`   | For the generated static implementation classes, `Java` will provide a static wrapper class for a singleton instance and `Kotlin` will use `object` instead of `class` | `true`      |
+| `language`                        | The target language for the generated classes. Either `Java` or `Kotlin`                                                                                               | `Java`      |
+| `includePattern`                  | A regular expression to only include certain templates                                                                                                                 | None        |
+| `excludePattern`                  | A regular expression to exclude certain templates                                                                                                                      | None        |
+| `interfaceName`                   | The name of the interface                                                                                                                                              | `Templates` |
 
 ##### Example { #model-extension-example }
 

--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -144,13 +144,16 @@ See details about it in the [jte-models documentation](jte-models.md).
 
 The following parameters are available for this extension:
 
-| Parameter                  | Description                                                               | Default |
-|----------------------------|---------------------------------------------------------------------------|---------|
-| `interfaceAnnotation`      | The FQCN of the annotation to add to the generated interface              | None    |
-| `implementationAnnotation` | The FQCN of the annotation to add to the generated implementation classes | None    |
-| `language`                 | The target language for the generated classes. Either `Java` or `Kotlin`  | `Java`  |
-| `includePattern`           | A regular expression to only include certain templates                    | None    |
-| `excludePattern`           | A regular expression to exclude certain templates                         | None    |
+| Parameter                         | Description                                                                                                                                                                                                 | Default |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `interfaceAnnotation`             | The FQCN of the annotation to add to the generated interface                                                                                                                                                | None    |
+| `implementationAnnotation`        | The FQCN of the annotation to add to the generated implementation classes                                                                                                                                   | None    |
+| `staticImplementationAnnotation`  | The FQCN of the annotation to add to the generated static implementation classes                                                                                                                            | None    |
+| `dynamicImplementationAnnotation` | The FQCN of the annotation to add to the generated dynamic implementation classes                                                                                                                           | None    |
+| `staticImplementationSingleton`   | For `Java`, the field name of the singleton instance to add to the generated static implementation class. For `Kotlin`, `true` to use `object` instead of `class` for generated static implementation class | None    |
+| `language`                        | The target language for the generated classes. Either `Java` or `Kotlin`                                                                                                                                    | `Java`  |
+| `includePattern`                  | A regular expression to only include certain templates                                                                                                                                                      | None    |
+| `excludePattern`                  | A regular expression to exclude certain templates                                                                                                                                                           | None    |
 
 ##### Example { #model-extension-example }
 

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
@@ -28,7 +28,7 @@ public class ModelConfig {
     }
 
     public String staticImplementationSingleton() {
-        return map.get("staticImplementationSingleton");
+        return map.getOrDefault("staticImplementationSingleton", "true");
     }
 
     public Language language() {

--- a/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
+++ b/jte-models/src/main/java/gg/jte/models/generator/ModelConfig.java
@@ -27,6 +27,10 @@ public class ModelConfig {
         return map.getOrDefault("dynamicImplementationAnnotation", "");
     }
 
+    public String staticImplementationSingleton() {
+        return map.get("staticImplementationSingleton");
+    }
+
     public Language language() {
         String configuredLanguage = map.getOrDefault("language", "Java");
         try {

--- a/jte-models/src/main/jte/statictemplates/kmain.jte
+++ b/jte-models/src/main/jte/statictemplates/kmain.jte
@@ -1,6 +1,8 @@
 @import gg.jte.extension.api.*
+@import gg.jte.models.generator.Util
 @import gg.jte.models.generator.ModelConfig
 @import java.util.Set
+@import java.util.stream.Collectors
 
 @param String targetClassName
 @param String interfaceName
@@ -21,8 +23,17 @@ import ${imp}
 
 ${modelConfig.implementationAnnotation()}
 ${modelConfig.staticImplementationAnnotation()}
-${"true".equalsIgnoreCase(modelConfig.staticImplementationSingleton()) ? "object" : "class"} ${targetClassName} : ${interfaceName} {
-    @for(TemplateDescription template: templates)
+class ${targetClassName} : ${interfaceName} {
+    @if("true".equalsIgnoreCase(modelConfig.staticImplementationSingleton()))
+    companion object {
+        val INSTANCE = ${targetClassName}();
+        @for(TemplateDescription template : templates)
+        !{final String methodName = Util.methodName(template);}
+        fun ${methodName}(${Util.kotlinTypedParams(template, true)}) = INSTANCE.${methodName}(${template.params().stream().map(ParamDescription::name).collect(Collectors.joining(","))});
+        @endfor
+    }
+    @endif
+    @for(TemplateDescription template : templates)
         @template.statictemplates.kmethod(config = config, template = template)
     @endfor
 }

--- a/jte-models/src/main/jte/statictemplates/kmain.jte
+++ b/jte-models/src/main/jte/statictemplates/kmain.jte
@@ -21,7 +21,7 @@ import ${imp}
 
 ${modelConfig.implementationAnnotation()}
 ${modelConfig.staticImplementationAnnotation()}
-class ${targetClassName} : ${interfaceName} {
+${"true".equalsIgnoreCase(modelConfig.staticImplementationSingleton()) ? "object" : "class"} ${targetClassName} : ${interfaceName} {
     @for(TemplateDescription template: templates)
         @template.statictemplates.kmethod(config = config, template = template)
     @endfor

--- a/jte-models/src/main/jte/statictemplates/main.jte
+++ b/jte-models/src/main/jte/statictemplates/main.jte
@@ -1,6 +1,8 @@
 @import gg.jte.extension.api.*
+@import gg.jte.models.generator.Util
 @import gg.jte.models.generator.ModelConfig
 @import java.util.Set
+@import java.util.stream.Collectors
 
 @param String targetClassName
 @param String interfaceName
@@ -24,11 +26,18 @@ ${modelConfig.implementationAnnotation()}
 ${modelConfig.staticImplementationAnnotation()}
 @javax.annotation.processing.Generated("gg.jte.TemplateEngine")
 public class ${targetClassName} implements ${interfaceName} {
-    !{final String staticImplementationSingletonName = modelConfig.staticImplementationSingleton();}
-    @if(staticImplementationSingletonName != null)
-    public static final ${targetClassName} ${staticImplementationSingletonName} = new ${targetClassName}();
+    @if("true".equalsIgnoreCase(modelConfig.staticImplementationSingleton()))
+    public static final ${targetClassName} INSTANCE = new ${targetClassName}();
+    public static final class Singleton {
+        @for(TemplateDescription template : templates)
+        !{final String methodName = Util.methodName(template);}
+        public static JteModel ${methodName}(${Util.typedParams(template)}) {
+            return INSTANCE.${methodName}(${template.params().stream().map(ParamDescription::name).collect(Collectors.joining(","))});
+        }
+        @endfor
+    }
     @endif
-    @for(TemplateDescription template: templates)
+    @for(TemplateDescription template : templates)
         @template.statictemplates.method(config = config, template = template)
     @endfor
 }

--- a/jte-models/src/main/jte/statictemplates/main.jte
+++ b/jte-models/src/main/jte/statictemplates/main.jte
@@ -24,6 +24,10 @@ ${modelConfig.implementationAnnotation()}
 ${modelConfig.staticImplementationAnnotation()}
 @javax.annotation.processing.Generated("gg.jte.TemplateEngine")
 public class ${targetClassName} implements ${interfaceName} {
+    !{final String staticImplementationSingletonName = modelConfig.staticImplementationSingleton();}
+    @if(staticImplementationSingletonName != null)
+    public static final ${targetClassName} ${staticImplementationSingletonName} = new ${targetClassName}();
+    @endif
     @for(TemplateDescription template: templates)
         @template.statictemplates.method(config = config, template = template)
     @endfor

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
@@ -36,14 +36,14 @@ public class TestModelConfig {
 
     @Test
     public void configureStaticImplementationSingleton() {
-        var modelConfig = new ModelConfig(Map.of("staticImplementationSingleton", "TEMPLATES"));
-        assertEquals("TEMPLATES", modelConfig.staticImplementationSingleton());
+        var modelConfig = new ModelConfig(Map.of("staticImplementationSingleton", "false"));
+        assertEquals("false", modelConfig.staticImplementationSingleton());
     }
 
     @Test
     public void staticImplementationSingletonNullWhenConfigurationNotPresent() {
         var modelConfig = new ModelConfig(Map.of());
-        assertNull(modelConfig.staticImplementationSingleton());
+        assertEquals("true", modelConfig.staticImplementationSingleton());
     }
 
     @Test

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelConfig.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestModelConfig {
@@ -31,6 +32,18 @@ public class TestModelConfig {
     public void implementationAnnotationNullWhenConfigurationNotPresent() {
         var modelConfig = new ModelConfig(Map.of());
         assertEquals("", modelConfig.implementationAnnotation());
+    }
+
+    @Test
+    public void configureStaticImplementationSingleton() {
+        var modelConfig = new ModelConfig(Map.of("staticImplementationSingleton", "TEMPLATES"));
+        assertEquals("TEMPLATES", modelConfig.staticImplementationSingleton());
+    }
+
+    @Test
+    public void staticImplementationSingletonNullWhenConfigurationNotPresent() {
+        var modelConfig = new ModelConfig(Map.of());
+        assertNull(modelConfig.staticImplementationSingleton());
     }
 
     @Test

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
@@ -48,7 +48,8 @@ public class TestModelExtension {
         @Test
         public void generateJavaFacades() {
             // Given
-            JteExtension modelExtension = new ModelExtension();
+            JteExtension modelExtension = new ModelExtension()
+                    .init(Map.of("staticImplementationSingleton", "TEMPLATES"));
             TemplateDescription templateDescription = mockTemplateDescription()
                     .packageName(TEST_PACKAGE)
                     .name("hello.jte")
@@ -87,6 +88,9 @@ public class TestModelExtension {
                 try {
                     String contents = Files.readString(path);
                     assertThat(contents).contains("JteModel hello(java.lang.String message)");
+                    if (STATIC_SOURCE_FILE.matcher(path.toString()).find()) {
+                        assertThat(contents).contains("public static final StaticTemplates TEMPLATES = new StaticTemplates();");
+                    }
                 } catch (IOException ex) {
                     fail("Could not read file " + path, ex);
                 }
@@ -105,6 +109,7 @@ public class TestModelExtension {
             JteExtension modelExtension = new ModelExtension();
             Map<String, String> config = new HashMap<>();
             config.put("language", Language.Kotlin.toString());
+            config.put("staticImplementationSingleton", "true");
             modelExtension.init(config);
 
             return modelExtension;
@@ -251,8 +256,7 @@ public class TestModelExtension {
                     import gg.jte.ContentType
                     import gg.jte.TemplateOutput
                     import gg.jte.html.HtmlTemplateOutput
-
-                    class StaticTemplates : Templates {
+                    object StaticTemplates : Templates {
                        \s
                         override fun hello(content: gg.jte.Content): JteModel = StaticJteModel<TemplateOutput>(
                             ContentType.Plain,
@@ -334,8 +338,7 @@ public class TestModelExtension {
                     import gg.jte.ContentType
                     import gg.jte.TemplateOutput
                     import gg.jte.html.HtmlTemplateOutput
-
-                    class StaticTemplates : Templates {
+                    object StaticTemplates : Templates {
                        \s
                         override fun hello(): JteModel = StaticJteModel<TemplateOutput>(
                             ContentType.Plain,

--- a/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
+++ b/jte-models/src/test/java/gg/jte/models/generator/TestModelExtension.java
@@ -13,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,8 +47,7 @@ public class TestModelExtension {
         @Test
         public void generateJavaFacades() {
             // Given
-            JteExtension modelExtension = new ModelExtension()
-                    .init(Map.of("staticImplementationSingleton", "TEMPLATES"));
+            JteExtension modelExtension = new ModelExtension();
             TemplateDescription templateDescription = mockTemplateDescription()
                     .packageName(TEST_PACKAGE)
                     .name("hello.jte")
@@ -89,7 +87,9 @@ public class TestModelExtension {
                     String contents = Files.readString(path);
                     assertThat(contents).contains("JteModel hello(java.lang.String message)");
                     if (STATIC_SOURCE_FILE.matcher(path.toString()).find()) {
-                        assertThat(contents).contains("public static final StaticTemplates TEMPLATES = new StaticTemplates();");
+                        assertThat(contents).contains("public static final StaticTemplates INSTANCE = new StaticTemplates();");
+                        assertThat(contents).contains("public static final class Singleton {");
+                        assertThat(contents).contains("public static JteModel hello(java.lang.String message)");
                     }
                 } catch (IOException ex) {
                     fail("Could not read file " + path, ex);
@@ -106,13 +106,7 @@ public class TestModelExtension {
         public static final Pattern STATIC_SOURCE_FILE = Pattern.compile("target.generated-test-sources." + TEST_PACKAGE + ".StaticTemplates.kt");
 
         private JteExtension kotlinModelExtension() {
-            JteExtension modelExtension = new ModelExtension();
-            Map<String, String> config = new HashMap<>();
-            config.put("language", Language.Kotlin.toString());
-            config.put("staticImplementationSingleton", "true");
-            modelExtension.init(config);
-
-            return modelExtension;
+            return new ModelExtension().init(Map.of("language", Language.Kotlin.toString()));
         }
 
         @Test
@@ -256,7 +250,15 @@ public class TestModelExtension {
                     import gg.jte.ContentType
                     import gg.jte.TemplateOutput
                     import gg.jte.html.HtmlTemplateOutput
-                    object StaticTemplates : Templates {
+
+                    class StaticTemplates : Templates {
+                       \s
+                        companion object {
+                            val INSTANCE = StaticTemplates();
+                           \s
+                            fun hello(content: gg.jte.Content) = INSTANCE.hello(content);
+                           \s
+                        }
                        \s
                         override fun hello(content: gg.jte.Content): JteModel = StaticJteModel<TemplateOutput>(
                             ContentType.Plain,
@@ -338,7 +340,15 @@ public class TestModelExtension {
                     import gg.jte.ContentType
                     import gg.jte.TemplateOutput
                     import gg.jte.html.HtmlTemplateOutput
-                    object StaticTemplates : Templates {
+
+                    class StaticTemplates : Templates {
+                       \s
+                        companion object {
+                            val INSTANCE = StaticTemplates();
+                           \s
+                            fun hello() = INSTANCE.hello();
+                           \s
+                        }
                        \s
                         override fun hello(): JteModel = StaticJteModel<TemplateOutput>(
                             ContentType.Plain,
@@ -372,6 +382,6 @@ public class TestModelExtension {
     }
 
     private static String withSystemLineEndings(String content) {
-        return content.replaceAll("\n", System.lineSeparator());
+        return content.replace("\n", System.lineSeparator());
     }
 }


### PR DESCRIPTION
For `jte-models`, the generated `StaticTemplates` class has no instance fields and its methods are effectively functions, so adding the ability to turn it into a singleton instance makes it easier to use e.g. `TEMPLATES.myHtmlTemplate().render()` instead of `new StaticTemplates().myHtmlTemplate().render()`.