### PR TITLE
Fix usePrecompiledTemplates missing from Spring configuration metadata in starter-4-core

### DIFF
--- a/jte-spring-boot-starter-4-core/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
+++ b/jte-spring-boot-starter-4-core/src/main/java/gg/jte/springframework/boot/autoconfigure/JteAutoConfiguration.java
@@ -21,10 +21,10 @@ public class JteAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(TemplateEngine.class)
     public TemplateEngine jteTemplateEngine(JteProperties jteProperties) {
-        if (jteProperties.isDevelopmentMode() && jteProperties.usePreCompiledTemplates()) {
+        if (jteProperties.isDevelopmentMode() && jteProperties.isUsePrecompiledTemplates()) {
             throw new JteConfigurationException("You can't use development mode and precompiledTemplates together");
         }
-        if (jteProperties.usePreCompiledTemplates()) {
+        if (jteProperties.isUsePrecompiledTemplates()) {
             // Templates will need to be compiled by the maven/gradle build task
             return TemplateEngine.createPrecompiled(ContentType.Html);
         }

--- a/jte-spring-boot-starter-4-core/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
+++ b/jte-spring-boot-starter-4-core/src/main/java/gg/jte/springframework/boot/autoconfigure/JteProperties.java
@@ -60,7 +60,11 @@ public class JteProperties {
         this.developmentMode = developmentMode;
     }
 
-    public boolean usePreCompiledTemplates() {
+	public boolean usePreCompiledTemplates() {
+		return usePrecompiledTemplates;
+	}
+
+    public boolean isUsePrecompiledTemplates() {
         return usePrecompiledTemplates;
     }
 


### PR DESCRIPTION
Renamed `usePreCompiledTemplates()` to `isUsePrecompiledTemplates()` in `JteProperties` to follow JavaBean naming conventions. The `spring-boot-configuration-processor` only recognizes boolean getters prefixed with `is`/`get`, `gg.jte.use-precompiled-templates` was silently excluded from the generated metadata, breaking IDE auto-complete.