### PR TITLE
Ignore csp.withgoogle.com in link validation

### DIFF
--- a/.github/workflows/validate-links.yml
+++ b/.github/workflows/validate-links.yml
@@ -17,7 +17,8 @@ jobs:
             --exclude "@template"
             --exclude test.com
             --exclude maven.apache.org
-            --exclude w3.org'
+            --exclude w3.org
+            --exclude "csp\.withgoogle\.com"'
           jobSummary: true
           format: markdown
           fail: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+csp\.withgoogle\.com

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,0 @@
-csp\.withgoogle\.com


### PR DESCRIPTION
Fixes #543

The domain keeps timing out in link validation. Easier to just skip it in the ignore file.