### PR TITLE
fix(530): add word-boundary check to @for and @if directive detection

### DIFF
--- a/jte/src/main/java/gg/jte/compiler/TemplateParser.java
+++ b/jte/src/main/java/gg/jte/compiler/TemplateParser.java
@@ -203,7 +203,7 @@ public final class TemplateParser {
                     extract(templateCode, lastIndex, i, visitor::onUnsafeCodePart);
                     lastIndex = i + 1;
                 }
-            } else if (currentMode == Mode.Text && regionMatches("@if")) {
+            } else if (currentMode == Mode.Text && regionMatches("@if") && (nextChar() == '(' || Character.isWhitespace(nextChar()))) {
                 extractTextPart(i - 2, Mode.Condition);
                 lastIndex = i + 1;
                 push(Mode.Condition);
@@ -298,7 +298,7 @@ public final class TemplateParser {
                     visitor.onConditionEnd(depth);
                     pop();
                 }
-            } else if (currentMode == Mode.Text && regionMatches("@for")) {
+            } else if (currentMode == Mode.Text && regionMatches("@for") && (nextChar() == '(' || Character.isWhitespace(nextChar()))) {
                 extractTextPart(i - 3, Mode.ForLoop);
                 lastIndex = i + 1;
                 push(Mode.ForLoop);

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -919,6 +919,12 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void urlWithAtIfInAttribute() {
+        givenTemplate("<a href=\"https://example.com/@iffy-path/page\">link</a>");
+        thenOutputIs("<a href=\"https://example.com/@iffy-path/page\">link</a>");
+    }
+
+    @Test
     void paramAfterText() {
         givenTemplate("Hello @param");
         thenOutputIs("Hello @param");

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -913,6 +913,12 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void urlWithAtForInAttribute() {
+        givenTemplate("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.1/css/all.min.css\">");
+        thenOutputIs("<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.1/css/all.min.css\">");
+    }
+
+    @Test
     void paramAfterText() {
         givenTemplate("Hello @param");
         thenOutputIs("Hello @param");


### PR DESCRIPTION
URLs containing @for or @if (e.g. @fortawesome) were incorrectly parsed as JTE directives because regionMatches() matched the keyword without checking the following character. Require the next char to be '(' or whitespace, consistent with how @else already guards against @elseif.