### PR TITLE
Test and fix for parameter with annotations using "="

### DIFF
--- a/jte/src/main/java/gg/jte/compiler/java/JavaParamInfo.java
+++ b/jte/src/main/java/gg/jte/compiler/java/JavaParamInfo.java
@@ -12,6 +12,7 @@ public class JavaParamInfo {
         int nameEndIndex = -1;
         int defaultValueStartIndex = -1;
         int genericDepth = 0;
+        int parenDepth = 0;
 
         boolean stringMode = false;
         for (int i = 0; i < parameterString.length(); ++i) {
@@ -40,9 +41,13 @@ public class JavaParamInfo {
                 ++genericDepth;
             } else if (character == '>') {
                 --genericDepth;
+            } else if (character == '(') {
+                ++parenDepth;
+            } else if (character == ')') {
+                --parenDepth;
             }
 
-            if (genericDepth > 0) {
+            if (genericDepth > 0 || parenDepth > 0) {
                 continue;
             }
 

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -1691,6 +1691,86 @@ public class TemplateEngineTest {
         assertThat(output.toString()).isEqualTo("test value");
     }
 
+    @Test
+    void annotatedParam_withDefaultValue() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotation
+        @param @TypeUseAnnotation String model = "default"
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_assign_withDefaultValue() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotationParam
+        @param @TypeUseAnnotationParam(value = "x", count = 5) String model = "default"
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_generic() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotation
+        @import java.util.List
+        @param @TypeUseAnnotation List<String> model
+        ${model.get(0)}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, List.of("test value"), output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_arrayValue() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.AnnWithArray
+        @param @AnnWithArray(values = {"a", "b"}) String model
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_multiple_assign() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotationParam
+        @import gg.jte.TestUtils.Nest1
+        @import gg.jte.TestUtils.Nested
+        @param @TypeUseAnnotationParam(value = "x") @Nest1(nested = @Nested) String model
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_arrayType() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotation
+        @param @TypeUseAnnotation String[] model
+        ${model[0]}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, new String[]{"test value"}, output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_escapedString() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotationParam
+        @param @TypeUseAnnotationParam("a \\"quoted\\" string") String model
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
     private void givenTemplate(String name, String code) {
         dummyCodeResolver.givenCode(name, code);
     }

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -1611,10 +1611,44 @@ public class TemplateEngineTest {
     }
 
     @Test
-    void annotation_issue433() {
+    void annotatedParam() {
         givenRawTemplate("""
         @import gg.jte.TestUtils.TypeUseAnnotation
         @param @TypeUseAnnotation String model
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_value() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotationParam
+        @param @TypeUseAnnotationParam("value") String model
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_assign() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotationParam
+        @param @TypeUseAnnotationParam(value = "value", count = 123) String model
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_multiple() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotation
+        @import gg.jte.TestUtils.TypeUseAnnotationParam
+        @param @TypeUseAnnotation @TypeUseAnnotationParam("value") String model
         ${model}""");
         StringOutput output = new StringOutput();
         templateEngine.render(templateName, "test value", output);

--- a/jte/src/test/java/gg/jte/TemplateEngineTest.java
+++ b/jte/src/test/java/gg/jte/TemplateEngineTest.java
@@ -1644,11 +1644,47 @@ public class TemplateEngineTest {
     }
 
     @Test
+    void annotatedParam_assignEnum() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.TypeUseAnnotationParam
+        @import gg.jte.TestUtils.TypeSelection
+        @param @TypeUseAnnotationParam(value = "value", typeSelection = TypeSelection.A) String model
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
     void annotatedParam_multiple() {
         givenRawTemplate("""
         @import gg.jte.TestUtils.TypeUseAnnotation
         @import gg.jte.TestUtils.TypeUseAnnotationParam
         @param @TypeUseAnnotation @TypeUseAnnotationParam("value") String model
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_nestedParens() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.Nest1
+        @import gg.jte.TestUtils.Nested
+        @param @Nest1(nested = @Nested()) String model
+        ${model}""");
+        StringOutput output = new StringOutput();
+        templateEngine.render(templateName, "test value", output);
+        assertThat(output.toString()).isEqualTo("test value");
+    }
+
+    @Test
+    void annotatedParam_nested() {
+        givenRawTemplate("""
+        @import gg.jte.TestUtils.Nest1
+        @import gg.jte.TestUtils.Nested
+        @param @Nest1(nested = @Nested) String model
         ${model}""");
         StringOutput output = new StringOutput();
         templateEngine.render(templateName, "test value", output);

--- a/jte/src/test/java/gg/jte/TestUtils.java
+++ b/jte/src/test/java/gg/jte/TestUtils.java
@@ -43,4 +43,11 @@ public class TestUtils {
     public @interface Nest1 {
         Nested nested();
     }
+
+    @SuppressWarnings("unused")
+    @Target({ElementType.TYPE_USE})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AnnWithArray {
+        String[] values();
+    }
 }

--- a/jte/src/test/java/gg/jte/TestUtils.java
+++ b/jte/src/test/java/gg/jte/TestUtils.java
@@ -24,5 +24,6 @@ public class TestUtils {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface TypeUseAnnotationParam {
         String value();
+        int count() default 0;
     }
 }

--- a/jte/src/test/java/gg/jte/TestUtils.java
+++ b/jte/src/test/java/gg/jte/TestUtils.java
@@ -13,6 +13,10 @@ public class TestUtils {
         return JAVA_VERSION >= 14; // Not really needed since we compile with jdk 17, but leave as pattern for the next Java version features.
     }
 
+    public enum TypeSelection {
+        A, B, C;
+    }
+
     @SuppressWarnings("unused") // see e.g. gg.jte.TemplateEngineTest.variadic_annotation
     @Target({ElementType.TYPE_USE})
     @Retention(RetentionPolicy.RUNTIME)
@@ -25,5 +29,18 @@ public class TestUtils {
     public @interface TypeUseAnnotationParam {
         String value();
         int count() default 0;
+        TypeSelection typeSelection() default TypeSelection.A;
+    }
+
+    @Target({ElementType.TYPE_USE})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Nested {
+        String value() default "something";
+    }
+
+    @Target({ElementType.TYPE_USE})
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Nest1 {
+        Nested nested();
     }
 }


### PR DESCRIPTION
Adds more test cases covering a variety of forms of annotations on params.

Fix the parser by detecting opening and closing parentheses. Resolves #433 