### PR TITLE
CLI app for standalone code generation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,7 +43,7 @@ Run with `--help` to see all options.
 | `-c, --content-type`            | The content type of all templates. Either `Plain` or `Html`                       | None. Required.                                                 |
 | `--trim-control-structures`     | Trims control structures, resulting in prettier output                            | `false`                                                         |
 | `--html-tags`                   | Intercepts the given (comma-separated) html tags during template compilation      | None                                                            |
-| `--html-comments-preserved`     | If HTML comments should be preserved in the output                                | `false`                                                         |
+| `--preserve-html-comments`      | If HTML comments should be preserved in the output                                | `false`                                                         |
 | `--binary-static-content`       | If to generate a [binary content](binary-rendering.md) resource for each template | `false`                                                         |
 | `--package-name`                | The package name, where template classes are generated to                         | [`Constants.PACKAGE_NAME_PRECOMPILED`][constants-package-name]  |
 | `--target-resource-directory`   | Directory in which to generate non-java files (resources)                         | None                                                            |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,60 @@
+---
+title: Command Line Interface
+description: How to use the jte command line tool to generate templates without Maven or Gradle.
+---
+
+If your project doesn't use Maven or Gradle (for example, a Clojure or Kotlin script project built with a different tool), you can still generate Java sources from your jte templates using the standalone `jte-cli` executable jar.
+
+!!! info "Generate only"
+
+    `jte-cli` only generates `.java` source files from your templates (equivalent to the Maven plugin's [`generate` goal](maven-plugin.md#generate-goal)). It does not compile them to `.class` files - your own build must compile the generated sources, the same way it compiles the rest of your project's Java code.
+
+!!! info "Java templates only"
+
+    `jte-cli` currently supports `.jte` (Java) templates only. `.kte` (Kotlin) templates aren't supported yet, since bundling the Kotlin compiler would make the jar much larger.
+
+## Download
+
+Download the executable jar directly from [Maven Central][jte-cli-central]:
+
+```shell linenums="1"
+curl -O https://repo1.maven.org/maven2/gg/jte/jte-cli/{{ latest-git-tag }}/jte-cli-{{ latest-git-tag }}-executable.jar
+```
+
+No Maven installation is required to fetch it - any tool that can download a file over HTTPS will do (`wget`, your browser, etc.). If your project happens to use Maven or Gradle for something else, you can alternatively declare it as a regular dependency with classifier `executable` (`gg.jte:jte-cli:{{ latest-git-tag }}:jar:executable`) and copy it out with the respective dependency plugin.
+
+## Usage
+
+```shell linenums="1"
+java -jar jte-cli-{{ latest-git-tag }}-executable.jar \
+    --source-directory src/main/jte \
+    --target-directory target/generated-sources/jte \
+    --content-type Html
+```
+
+Run with `--help` to see all options.
+
+### Options { #options }
+
+| Option                        | Description                                                                       | Default                                                        |
+|--------------------------------|------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| `-s, --source-directory`        | The directory where template files are located                                    | None. Required.                                                 |
+| `-t, --target-directory`        | Destination directory to store generated sources                                  | None. Required.                                                 |
+| `-c, --content-type`            | The content type of all templates. Either `Plain` or `Html`                       | None. Required.                                                 |
+| `--trim-control-structures`     | Trims control structures, resulting in prettier output                            | `false`                                                         |
+| `--html-tags`                   | Intercepts the given (comma-separated) html tags during template compilation      | None                                                            |
+| `--html-comments-preserved`     | If HTML comments should be preserved in the output                                | `false`                                                         |
+| `--binary-static-content`       | If to generate a [binary content](binary-rendering.md) resource for each template | `false`                                                         |
+| `--package-name`                | The package name, where template classes are generated to                         | [`Constants.PACKAGE_NAME_PRECOMPILED`][constants-package-name]  |
+| `--target-resource-directory`   | Directory in which to generate non-java files (resources)                         | None                                                            |
+
+!!! info "About `--binary-static-content` without `--target-resource-directory`"
+
+    When `--binary-static-content` is enabled, each template with static content gets a `.bin` resource file alongside its generated `.java` file. If `--target-resource-directory` isn't set, these `.bin` files are written into `--target-directory` itself, next to the generated sources. Either way, make sure your build copies them onto the runtime classpath - [`Utf8ByteOutput`](binary-rendering.md) loads them at render time.
+
+!!! info "No extension support yet"
+
+    Unlike the Maven/Gradle plugins, `jte-cli` doesn't support [extensions](maven-plugin.md#generate-extensions) (such as `ModelExtension`) yet. This may be added in a future version.
+
+[jte-cli-central]: https://central.sonatype.com/artifact/gg.jte/jte-cli
+[constants-package-name]: https://www.javadoc.io/doc/gg.jte/jte-runtime/{{ latest-git-tag }}/gg/jte.runtime/gg/jte/Constants.html#PACKAGE_NAME_PRECOMPILED

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,13 +26,13 @@ No Maven installation is required to fetch it - any tool that can download a fil
 ## Usage
 
 ```shell linenums="1"
-java -jar jte-cli-{{ latest-git-tag }}-executable.jar \
+java -jar jte-cli-{{ latest-git-tag }}-executable.jar generate \
     --source-directory src/main/jte \
     --target-directory target/generated-sources/jte \
     --content-type Html
 ```
 
-Run with `--help` to see all options.
+`generate` is currently the only command. Run with `--help` or `generate --help` to see all options.
 
 ### Options { #options }
 

--- a/jte-cli/pom.xml
+++ b/jte-cli/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jte-cli</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>gg.jte</groupId>
+        <artifactId>jte-parent</artifactId>
+        <version>3.2.5-SNAPSHOT</version>
+    </parent>
+
+    <name>jte-cli</name>
+    <description>Command line tool to generate jte templates to Java sources, without Maven or Gradle</description>
+
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
+        <picocli.version>4.7.7</picocli.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>gg.jte</groupId>
+            <artifactId>jte</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>${picocli.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>gg.jte.cli</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>executable</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>gg.jte.cli.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jte-cli/src/main/java/gg/jte/cli/GenerateCommand.java
+++ b/jte-cli/src/main/java/gg/jte/cli/GenerateCommand.java
@@ -1,0 +1,80 @@
+package gg.jte.cli;
+
+import gg.jte.ContentType;
+import gg.jte.TemplateEngine;
+import gg.jte.resolve.DirectoryCodeResolver;
+import gg.jte.runtime.Constants;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+@Command(name = "generate", mixinStandardHelpOptions = true,
+        description = "Generates Java sources from jte templates, without needing Maven or Gradle.")
+public class GenerateCommand implements Callable<Integer> {
+
+    @Option(names = {"-s", "--source-directory"}, required = true, description = "The directory where template files are located.")
+    public Path sourceDirectory;
+
+    @Option(names = {"-t", "--target-directory"}, required = true, description = "Destination directory to store generated sources.")
+    public Path targetDirectory;
+
+    @Option(names = {"-c", "--content-type"}, required = true, description = "The content type of all templates: ${COMPLETION-CANDIDATES}.")
+    public ContentType contentType;
+
+    @Option(names = "--trim-control-structures", description = "Trims control structures, resulting in prettier output.")
+    public boolean trimControlStructures;
+
+    @Option(names = "--html-tags", split = ",", description = "Intercepts the given html tags during template compilation.")
+    public String[] htmlTags;
+
+    @Option(names = "--preserve-html-comments", description = "Preserves HTML/CSS/JS comments, which are omitted by default when using Html content type.")
+    public boolean htmlCommentsPreserved;
+
+    @Option(names = "--binary-static-content", description = "UTF-8 encodes all static template parts at compile time.")
+    public boolean binaryStaticContent;
+
+    @Option(names = "--package-name", description = "The package name, where template classes are generated to. Defaults to ${DEFAULT-VALUE}.")
+    public String packageName = Constants.PACKAGE_NAME_PRECOMPILED;
+
+    @Option(names = "--target-resource-directory", description = "Directory in which to generate non-java files (resources).")
+    public Path targetResourceDirectory;
+
+    @Override
+    public Integer call() {
+        if (!Files.isDirectory(sourceDirectory)) {
+            System.err.println("Error: source directory " + sourceDirectory + " does not exist.");
+            return 1;
+        }
+
+        try {
+            Files.createDirectories(targetDirectory);
+        } catch (IOException e) {
+            System.err.println("Error: target directory " + targetDirectory + " is not writable: " + e.getMessage());
+            return 1;
+        }
+
+        long start = System.nanoTime();
+        int amount = run();
+        long durationMs = (System.nanoTime() - start) / 1_000_000;
+        System.out.println("Successfully generated " + amount + " jte file" + (amount == 1 ? "" : "s") + " in " + durationMs + "ms to " + targetDirectory);
+        return 0;
+    }
+
+    int run() {
+        TemplateEngine templateEngine = TemplateEngine.create(new DirectoryCodeResolver(sourceDirectory), targetDirectory, contentType, null, packageName);
+        templateEngine.setTrimControlStructures(trimControlStructures);
+        templateEngine.setHtmlTags(htmlTags);
+        templateEngine.setHtmlCommentsPreserved(htmlCommentsPreserved);
+        templateEngine.setBinaryStaticContent(binaryStaticContent);
+        if (targetResourceDirectory != null) {
+            templateEngine.setTargetResourceDirectory(targetResourceDirectory);
+        }
+
+        templateEngine.cleanAll();
+        return templateEngine.generateAll().size();
+    }
+}

--- a/jte-cli/src/main/java/gg/jte/cli/Main.java
+++ b/jte-cli/src/main/java/gg/jte/cli/Main.java
@@ -1,0 +1,91 @@
+package gg.jte.cli;
+
+import gg.jte.ContentType;
+import gg.jte.TemplateEngine;
+import gg.jte.resolve.DirectoryCodeResolver;
+import gg.jte.runtime.Constants;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+@Command(name = "jte-cli", mixinStandardHelpOptions = true,
+        description = "Generates Java sources from jte templates, without needing Maven or Gradle.")
+public class Main implements Callable<Integer> {
+
+    @Option(names = {"-s", "--source-directory"}, required = true, description = "The directory where template files are located.")
+    public Path sourceDirectory;
+
+    @Option(names = {"-t", "--target-directory"}, required = true, description = "Destination directory to store generated sources.")
+    public Path targetDirectory;
+
+    @Option(names = {"-c", "--content-type"}, required = true, description = "The content type of all templates: ${COMPLETION-CANDIDATES}.")
+    public ContentType contentType;
+
+    @Option(names = "--trim-control-structures", description = "Trims control structures, resulting in prettier output.")
+    public boolean trimControlStructures;
+
+    @Option(names = "--html-tags", split = ",", description = "Intercepts the given html tags during template compilation.")
+    public String[] htmlTags;
+
+    @Option(names = "--html-comments-preserved", description = "Preserves HTML/CSS/JS comments, which are omitted by default when using Html content type.")
+    public boolean htmlCommentsPreserved;
+
+    @Option(names = "--binary-static-content", description = "UTF-8 encodes all static template parts at compile time.")
+    public boolean binaryStaticContent;
+
+    @Option(names = "--package-name", description = "The package name, where template classes are generated to. Defaults to ${DEFAULT-VALUE}.")
+    public String packageName = Constants.PACKAGE_NAME_PRECOMPILED;
+
+    @Option(names = "--target-resource-directory", description = "Directory in which to generate non-java files (resources).")
+    public Path targetResourceDirectory;
+
+    public static void main(String[] args) {
+        System.exit(newCommandLine(new Main()).execute(args));
+    }
+
+    static CommandLine newCommandLine(Main main) {
+        CommandLine commandLine = new CommandLine(main);
+        commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+        return commandLine;
+    }
+
+    @Override
+    public Integer call() {
+        if (!Files.isDirectory(sourceDirectory)) {
+            System.err.println("Error: source directory " + sourceDirectory + " does not exist.");
+            return 1;
+        }
+
+        try {
+            Files.createDirectories(targetDirectory);
+        } catch (IOException e) {
+            System.err.println("Error: target directory " + targetDirectory + " is not writable: " + e.getMessage());
+            return 1;
+        }
+
+        long start = System.nanoTime();
+        int amount = run();
+        long durationMs = (System.nanoTime() - start) / 1_000_000;
+        System.out.println("Successfully generated " + amount + " jte file" + (amount == 1 ? "" : "s") + " in " + durationMs + "ms to " + targetDirectory);
+        return 0;
+    }
+
+    int run() {
+        TemplateEngine templateEngine = TemplateEngine.create(new DirectoryCodeResolver(sourceDirectory), targetDirectory, contentType, null, packageName);
+        templateEngine.setTrimControlStructures(trimControlStructures);
+        templateEngine.setHtmlTags(htmlTags);
+        templateEngine.setHtmlCommentsPreserved(htmlCommentsPreserved);
+        templateEngine.setBinaryStaticContent(binaryStaticContent);
+        if (targetResourceDirectory != null) {
+            templateEngine.setTargetResourceDirectory(targetResourceDirectory);
+        }
+
+        templateEngine.cleanAll();
+        return templateEngine.generateAll().size();
+    }
+}

--- a/jte-cli/src/main/java/gg/jte/cli/Main.java
+++ b/jte-cli/src/main/java/gg/jte/cli/Main.java
@@ -32,7 +32,7 @@ public class Main implements Callable<Integer> {
     @Option(names = "--html-tags", split = ",", description = "Intercepts the given html tags during template compilation.")
     public String[] htmlTags;
 
-    @Option(names = "--html-comments-preserved", description = "Preserves HTML/CSS/JS comments, which are omitted by default when using Html content type.")
+    @Option(names = "--preserve-html-comments", description = "Preserves HTML/CSS/JS comments, which are omitted by default when using Html content type.")
     public boolean htmlCommentsPreserved;
 
     @Option(names = "--binary-static-content", description = "UTF-8 encodes all static template parts at compile time.")

--- a/jte-cli/src/main/java/gg/jte/cli/Main.java
+++ b/jte-cli/src/main/java/gg/jte/cli/Main.java
@@ -1,48 +1,14 @@
 package gg.jte.cli;
 
-import gg.jte.ContentType;
-import gg.jte.TemplateEngine;
-import gg.jte.resolve.DirectoryCodeResolver;
-import gg.jte.runtime.Constants;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
 @Command(name = "jte-cli", mixinStandardHelpOptions = true,
-        description = "Generates Java sources from jte templates, without needing Maven or Gradle.")
+        description = "Command line tool for jte template generation, without needing Maven or Gradle.",
+        subcommands = {GenerateCommand.class})
 public class Main implements Callable<Integer> {
-
-    @Option(names = {"-s", "--source-directory"}, required = true, description = "The directory where template files are located.")
-    public Path sourceDirectory;
-
-    @Option(names = {"-t", "--target-directory"}, required = true, description = "Destination directory to store generated sources.")
-    public Path targetDirectory;
-
-    @Option(names = {"-c", "--content-type"}, required = true, description = "The content type of all templates: ${COMPLETION-CANDIDATES}.")
-    public ContentType contentType;
-
-    @Option(names = "--trim-control-structures", description = "Trims control structures, resulting in prettier output.")
-    public boolean trimControlStructures;
-
-    @Option(names = "--html-tags", split = ",", description = "Intercepts the given html tags during template compilation.")
-    public String[] htmlTags;
-
-    @Option(names = "--preserve-html-comments", description = "Preserves HTML/CSS/JS comments, which are omitted by default when using Html content type.")
-    public boolean htmlCommentsPreserved;
-
-    @Option(names = "--binary-static-content", description = "UTF-8 encodes all static template parts at compile time.")
-    public boolean binaryStaticContent;
-
-    @Option(names = "--package-name", description = "The package name, where template classes are generated to. Defaults to ${DEFAULT-VALUE}.")
-    public String packageName = Constants.PACKAGE_NAME_PRECOMPILED;
-
-    @Option(names = "--target-resource-directory", description = "Directory in which to generate non-java files (resources).")
-    public Path targetResourceDirectory;
 
     public static void main(String[] args) {
         System.exit(newCommandLine(new Main()).execute(args));
@@ -51,41 +17,12 @@ public class Main implements Callable<Integer> {
     static CommandLine newCommandLine(Main main) {
         CommandLine commandLine = new CommandLine(main);
         commandLine.setCaseInsensitiveEnumValuesAllowed(true);
+        commandLine.getSubcommands().values().forEach(sub -> sub.setCaseInsensitiveEnumValuesAllowed(true));
         return commandLine;
     }
 
     @Override
     public Integer call() {
-        if (!Files.isDirectory(sourceDirectory)) {
-            System.err.println("Error: source directory " + sourceDirectory + " does not exist.");
-            return 1;
-        }
-
-        try {
-            Files.createDirectories(targetDirectory);
-        } catch (IOException e) {
-            System.err.println("Error: target directory " + targetDirectory + " is not writable: " + e.getMessage());
-            return 1;
-        }
-
-        long start = System.nanoTime();
-        int amount = run();
-        long durationMs = (System.nanoTime() - start) / 1_000_000;
-        System.out.println("Successfully generated " + amount + " jte file" + (amount == 1 ? "" : "s") + " in " + durationMs + "ms to " + targetDirectory);
-        return 0;
-    }
-
-    int run() {
-        TemplateEngine templateEngine = TemplateEngine.create(new DirectoryCodeResolver(sourceDirectory), targetDirectory, contentType, null, packageName);
-        templateEngine.setTrimControlStructures(trimControlStructures);
-        templateEngine.setHtmlTags(htmlTags);
-        templateEngine.setHtmlCommentsPreserved(htmlCommentsPreserved);
-        templateEngine.setBinaryStaticContent(binaryStaticContent);
-        if (targetResourceDirectory != null) {
-            templateEngine.setTargetResourceDirectory(targetResourceDirectory);
-        }
-
-        templateEngine.cleanAll();
-        return templateEngine.generateAll().size();
+        throw new CommandLine.ParameterException(new CommandLine(this), "Missing required subcommand, try 'jte-cli generate --help'.");
     }
 }

--- a/jte-cli/src/test/java/gg/jte/cli/CliArgsTest.java
+++ b/jte-cli/src/test/java/gg/jte/cli/CliArgsTest.java
@@ -18,7 +18,7 @@ class CliArgsTest {
                 "-c", "Html",
                 "--trim-control-structures",
                 "--html-tags", "form,input",
-                "--html-comments-preserved",
+                "--preserve-html-comments",
                 "--binary-static-content",
                 "--package-name", "com.example.templates",
                 "--target-resource-directory", "target/resources"

--- a/jte-cli/src/test/java/gg/jte/cli/CliArgsTest.java
+++ b/jte-cli/src/test/java/gg/jte/cli/CliArgsTest.java
@@ -2,6 +2,7 @@ package gg.jte.cli;
 
 import gg.jte.ContentType;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 import java.nio.file.Path;
 
@@ -11,8 +12,8 @@ class CliArgsTest {
 
     @Test
     void parsesAllOptions() {
-        Main main = new Main();
-        Main.newCommandLine(main).parseArgs(
+        GenerateCommand generateCommand = parseGenerate(
+                "generate",
                 "-s", "src/jte",
                 "-t", "target/generated",
                 "-c", "Html",
@@ -24,32 +25,35 @@ class CliArgsTest {
                 "--target-resource-directory", "target/resources"
         );
 
-        assertThat(main.sourceDirectory).isEqualTo(Path.of("src/jte"));
-        assertThat(main.targetDirectory).isEqualTo(Path.of("target/generated"));
-        assertThat(main.contentType).isEqualTo(ContentType.Html);
-        assertThat(main.trimControlStructures).isTrue();
-        assertThat(main.htmlTags).containsExactly("form", "input");
-        assertThat(main.htmlCommentsPreserved).isTrue();
-        assertThat(main.binaryStaticContent).isTrue();
-        assertThat(main.packageName).isEqualTo("com.example.templates");
-        assertThat(main.targetResourceDirectory).isEqualTo(Path.of("target/resources"));
+        assertThat(generateCommand.sourceDirectory).isEqualTo(Path.of("src/jte"));
+        assertThat(generateCommand.targetDirectory).isEqualTo(Path.of("target/generated"));
+        assertThat(generateCommand.contentType).isEqualTo(ContentType.Html);
+        assertThat(generateCommand.trimControlStructures).isTrue();
+        assertThat(generateCommand.htmlTags).containsExactly("form", "input");
+        assertThat(generateCommand.htmlCommentsPreserved).isTrue();
+        assertThat(generateCommand.binaryStaticContent).isTrue();
+        assertThat(generateCommand.packageName).isEqualTo("com.example.templates");
+        assertThat(generateCommand.targetResourceDirectory).isEqualTo(Path.of("target/resources"));
     }
 
     @Test
     void defaultsPackageNameAndRequiresSourceTargetAndContentType() {
-        Main main = new Main();
-        Main.newCommandLine(main).parseArgs("-s", "src/jte", "-t", "target/generated", "-c", "Plain");
+        GenerateCommand generateCommand = parseGenerate("generate", "-s", "src/jte", "-t", "target/generated", "-c", "Plain");
 
-        assertThat(main.packageName).isEqualTo("gg.jte.generated.precompiled");
-        assertThat(main.trimControlStructures).isFalse();
-        assertThat(main.htmlTags).isNull();
+        assertThat(generateCommand.packageName).isEqualTo("gg.jte.generated.precompiled");
+        assertThat(generateCommand.trimControlStructures).isFalse();
+        assertThat(generateCommand.htmlTags).isNull();
     }
 
     @Test
     void parsesContentTypeCaseInsensitively() {
-        Main main = new Main();
-        Main.newCommandLine(main).parseArgs("-s", "src/jte", "-t", "target/generated", "-c", "html");
+        GenerateCommand generateCommand = parseGenerate("generate", "-s", "src/jte", "-t", "target/generated", "-c", "html");
 
-        assertThat(main.contentType).isEqualTo(ContentType.Html);
+        assertThat(generateCommand.contentType).isEqualTo(ContentType.Html);
+    }
+
+    private static GenerateCommand parseGenerate(String... args) {
+        CommandLine.ParseResult result = Main.newCommandLine(new Main()).parseArgs(args);
+        return (GenerateCommand) result.subcommand().commandSpec().userObject();
     }
 }

--- a/jte-cli/src/test/java/gg/jte/cli/CliArgsTest.java
+++ b/jte-cli/src/test/java/gg/jte/cli/CliArgsTest.java
@@ -1,0 +1,55 @@
+package gg.jte.cli;
+
+import gg.jte.ContentType;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CliArgsTest {
+
+    @Test
+    void parsesAllOptions() {
+        Main main = new Main();
+        Main.newCommandLine(main).parseArgs(
+                "-s", "src/jte",
+                "-t", "target/generated",
+                "-c", "Html",
+                "--trim-control-structures",
+                "--html-tags", "form,input",
+                "--html-comments-preserved",
+                "--binary-static-content",
+                "--package-name", "com.example.templates",
+                "--target-resource-directory", "target/resources"
+        );
+
+        assertThat(main.sourceDirectory).isEqualTo(Path.of("src/jte"));
+        assertThat(main.targetDirectory).isEqualTo(Path.of("target/generated"));
+        assertThat(main.contentType).isEqualTo(ContentType.Html);
+        assertThat(main.trimControlStructures).isTrue();
+        assertThat(main.htmlTags).containsExactly("form", "input");
+        assertThat(main.htmlCommentsPreserved).isTrue();
+        assertThat(main.binaryStaticContent).isTrue();
+        assertThat(main.packageName).isEqualTo("com.example.templates");
+        assertThat(main.targetResourceDirectory).isEqualTo(Path.of("target/resources"));
+    }
+
+    @Test
+    void defaultsPackageNameAndRequiresSourceTargetAndContentType() {
+        Main main = new Main();
+        Main.newCommandLine(main).parseArgs("-s", "src/jte", "-t", "target/generated", "-c", "Plain");
+
+        assertThat(main.packageName).isEqualTo("gg.jte.generated.precompiled");
+        assertThat(main.trimControlStructures).isFalse();
+        assertThat(main.htmlTags).isNull();
+    }
+
+    @Test
+    void parsesContentTypeCaseInsensitively() {
+        Main main = new Main();
+        Main.newCommandLine(main).parseArgs("-s", "src/jte", "-t", "target/generated", "-c", "html");
+
+        assertThat(main.contentType).isEqualTo(ContentType.Html);
+    }
+}

--- a/jte-cli/src/test/java/gg/jte/cli/GenerateCommandCallTest.java
+++ b/jte-cli/src/test/java/gg/jte/cli/GenerateCommandCallTest.java
@@ -14,11 +14,11 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class MainCallTest {
+class GenerateCommandCallTest {
 
     @Test
     void printsFriendlyErrorWhenSourceDirectoryDoesNotExist(@TempDir Path tempDir) {
-        Main main = new Main();
+        GenerateCommand main = new GenerateCommand();
         main.sourceDirectory = tempDir.resolve("does-not-exist");
         main.targetDirectory = tempDir.resolve("generated");
         main.contentType = ContentType.Plain;
@@ -41,7 +41,7 @@ class MainCallTest {
         assertThat(readOnlyDirectory.toFile().setWritable(false)).isTrue();
 
         try {
-            Main main = new Main();
+            GenerateCommand main = new GenerateCommand();
             main.sourceDirectory = sourceDirectory;
             main.targetDirectory = readOnlyDirectory.resolve("generated");
             main.contentType = ContentType.Plain;
@@ -55,7 +55,7 @@ class MainCallTest {
         }
     }
 
-    private static String callAndCaptureStderr(Main main) {
+    private static String callAndCaptureStderr(GenerateCommand main) {
         ByteArrayOutputStream err = new ByteArrayOutputStream();
         PrintStream originalErr = System.err;
         System.setErr(new PrintStream(err));

--- a/jte-cli/src/test/java/gg/jte/cli/GenerateCommandTest.java
+++ b/jte-cli/src/test/java/gg/jte/cli/GenerateCommandTest.java
@@ -1,0 +1,110 @@
+package gg.jte.cli;
+
+import gg.jte.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GenerateCommandTest {
+
+    Path sourceDirectory;
+    Path targetDirectory;
+    GenerateCommand main;
+
+    @BeforeEach
+    void setUp(@TempDir Path tempDir) throws IOException {
+        sourceDirectory = tempDir.resolve("templates");
+        targetDirectory = tempDir.resolve("generated");
+        Files.createDirectories(sourceDirectory);
+
+        main = new GenerateCommand();
+        main.sourceDirectory = sourceDirectory;
+        main.targetDirectory = targetDirectory;
+    }
+
+    @Test
+    void generatesJavaSourceFromTemplate() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "@param String name\nHello, ${name}!");
+        main.contentType = ContentType.Plain;
+
+        int amount = main.run();
+
+        assertThat(amount).isEqualTo(1);
+        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
+        assertThat(generated).exists();
+        assertThat(Files.readString(generated)).contains("Hello, ");
+    }
+
+    @Test
+    void usesCustomPackageName() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "Hello!");
+        main.contentType = ContentType.Plain;
+        main.packageName = "com.example.templates";
+
+        main.run();
+
+        Path generated = targetDirectory.resolve("com/example/templates/JtehelloGenerated.java");
+        assertThat(generated).exists();
+        assertThat(Files.readString(generated)).contains("package com.example.templates;");
+    }
+
+    @Test
+    void trimsControlStructuresWhenEnabled() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "before\n@if(true)\nyes\n@endif\nafter");
+        main.contentType = ContentType.Plain;
+
+        main.run();
+        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
+        String untrimmed = Files.readString(generated);
+
+        main.trimControlStructures = true;
+        main.run();
+        String trimmed = Files.readString(generated);
+
+        assertThat(trimmed).isNotEqualTo(untrimmed);
+    }
+
+    @Test
+    void interceptsConfiguredHtmlTags() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "<form action=\"a\">\n</form>");
+        main.contentType = ContentType.Html;
+        main.htmlTags = new String[]{"form"};
+
+        main.run();
+
+        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
+        assertThat(Files.readString(generated)).contains("jteHtmlInterceptor.onHtmlTagOpened(\"form\"");
+    }
+
+    @Test
+    void preservesHtmlCommentsWhenEnabled() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "<!--a comment-->");
+        main.contentType = ContentType.Html;
+        main.htmlCommentsPreserved = true;
+
+        main.run();
+
+        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
+        assertThat(Files.readString(generated)).contains("a comment");
+    }
+
+    @Test
+    void generatesBinaryStaticContentToTargetResourceDirectory() throws IOException {
+        Path resourceDirectory = sourceDirectory.getParent().resolve("resources");
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "Hello!");
+        main.contentType = ContentType.Plain;
+        main.binaryStaticContent = true;
+        main.targetResourceDirectory = resourceDirectory;
+
+        main.run();
+
+        Path resourceFile = resourceDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.bin");
+        assertThat(resourceFile).exists();
+    }
+}

--- a/jte-cli/src/test/java/gg/jte/cli/MainCallTest.java
+++ b/jte-cli/src/test/java/gg/jte/cli/MainCallTest.java
@@ -1,0 +1,72 @@
+package gg.jte.cli;
+
+import gg.jte.ContentType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MainCallTest {
+
+    @Test
+    void printsFriendlyErrorWhenSourceDirectoryDoesNotExist(@TempDir Path tempDir) {
+        Main main = new Main();
+        main.sourceDirectory = tempDir.resolve("does-not-exist");
+        main.targetDirectory = tempDir.resolve("generated");
+        main.contentType = ContentType.Plain;
+
+        String err = callAndCaptureStderr(main);
+
+        assertThat(err).contains("source directory").contains(main.sourceDirectory.toString()).contains("does not exist");
+        assertThat(err).doesNotContain("Exception");
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void printsFriendlyErrorWhenTargetDirectoryIsNotWritable(@TempDir Path tempDir) throws IOException {
+        Path sourceDirectory = tempDir.resolve("templates");
+        Files.createDirectories(sourceDirectory);
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "Hello!");
+
+        Path readOnlyDirectory = tempDir.resolve("readonly");
+        Files.createDirectories(readOnlyDirectory);
+        assertThat(readOnlyDirectory.toFile().setWritable(false)).isTrue();
+
+        try {
+            Main main = new Main();
+            main.sourceDirectory = sourceDirectory;
+            main.targetDirectory = readOnlyDirectory.resolve("generated");
+            main.contentType = ContentType.Plain;
+
+            String err = callAndCaptureStderr(main);
+
+            assertThat(err).contains("target directory").contains(main.targetDirectory.toString());
+            assertThat(err).doesNotContain("Exception");
+        } finally {
+            readOnlyDirectory.toFile().setWritable(true);
+        }
+    }
+
+    private static String callAndCaptureStderr(Main main) {
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(err));
+        int exitCode;
+        try {
+            exitCode = main.call();
+        } finally {
+            System.setErr(originalErr);
+        }
+
+        assertThat(exitCode).isEqualTo(1);
+        return err.toString();
+    }
+}

--- a/jte-cli/src/test/java/gg/jte/cli/MainTest.java
+++ b/jte-cli/src/test/java/gg/jte/cli/MainTest.java
@@ -1,110 +1,34 @@
 package gg.jte.cli;
 
-import gg.jte.ContentType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MainTest {
 
-    Path sourceDirectory;
-    Path targetDirectory;
-    Main main;
+    @Test
+    void printsFriendlyErrorWhenNoSubcommandGiven() {
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(err));
+        int exitCode;
+        try {
+            exitCode = Main.newCommandLine(new Main()).execute();
+        } finally {
+            System.setErr(originalErr);
+        }
 
-    @BeforeEach
-    void setUp(@TempDir Path tempDir) throws IOException {
-        sourceDirectory = tempDir.resolve("templates");
-        targetDirectory = tempDir.resolve("generated");
-        Files.createDirectories(sourceDirectory);
-
-        main = new Main();
-        main.sourceDirectory = sourceDirectory;
-        main.targetDirectory = targetDirectory;
+        assertThat(exitCode).isNotEqualTo(0);
+        assertThat(err.toString()).contains("generate");
     }
 
     @Test
-    void generatesJavaSourceFromTemplate() throws IOException {
-        Files.writeString(sourceDirectory.resolve("hello.jte"), "@param String name\nHello, ${name}!");
-        main.contentType = ContentType.Plain;
+    void dispatchesToGenerateSubcommand() {
+        int exitCode = Main.newCommandLine(new Main()).execute("generate", "--help");
 
-        int amount = main.run();
-
-        assertThat(amount).isEqualTo(1);
-        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
-        assertThat(generated).exists();
-        assertThat(Files.readString(generated)).contains("Hello, ");
-    }
-
-    @Test
-    void usesCustomPackageName() throws IOException {
-        Files.writeString(sourceDirectory.resolve("hello.jte"), "Hello!");
-        main.contentType = ContentType.Plain;
-        main.packageName = "com.example.templates";
-
-        main.run();
-
-        Path generated = targetDirectory.resolve("com/example/templates/JtehelloGenerated.java");
-        assertThat(generated).exists();
-        assertThat(Files.readString(generated)).contains("package com.example.templates;");
-    }
-
-    @Test
-    void trimsControlStructuresWhenEnabled() throws IOException {
-        Files.writeString(sourceDirectory.resolve("hello.jte"), "before\n@if(true)\nyes\n@endif\nafter");
-        main.contentType = ContentType.Plain;
-
-        main.run();
-        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
-        String untrimmed = Files.readString(generated);
-
-        main.trimControlStructures = true;
-        main.run();
-        String trimmed = Files.readString(generated);
-
-        assertThat(trimmed).isNotEqualTo(untrimmed);
-    }
-
-    @Test
-    void interceptsConfiguredHtmlTags() throws IOException {
-        Files.writeString(sourceDirectory.resolve("hello.jte"), "<form action=\"a\">\n</form>");
-        main.contentType = ContentType.Html;
-        main.htmlTags = new String[]{"form"};
-
-        main.run();
-
-        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
-        assertThat(Files.readString(generated)).contains("jteHtmlInterceptor.onHtmlTagOpened(\"form\"");
-    }
-
-    @Test
-    void preservesHtmlCommentsWhenEnabled() throws IOException {
-        Files.writeString(sourceDirectory.resolve("hello.jte"), "<!--a comment-->");
-        main.contentType = ContentType.Html;
-        main.htmlCommentsPreserved = true;
-
-        main.run();
-
-        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
-        assertThat(Files.readString(generated)).contains("a comment");
-    }
-
-    @Test
-    void generatesBinaryStaticContentToTargetResourceDirectory() throws IOException {
-        Path resourceDirectory = sourceDirectory.getParent().resolve("resources");
-        Files.writeString(sourceDirectory.resolve("hello.jte"), "Hello!");
-        main.contentType = ContentType.Plain;
-        main.binaryStaticContent = true;
-        main.targetResourceDirectory = resourceDirectory;
-
-        main.run();
-
-        Path resourceFile = resourceDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.bin");
-        assertThat(resourceFile).exists();
+        assertThat(exitCode).isEqualTo(0);
     }
 }

--- a/jte-cli/src/test/java/gg/jte/cli/MainTest.java
+++ b/jte-cli/src/test/java/gg/jte/cli/MainTest.java
@@ -1,0 +1,110 @@
+package gg.jte.cli;
+
+import gg.jte.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MainTest {
+
+    Path sourceDirectory;
+    Path targetDirectory;
+    Main main;
+
+    @BeforeEach
+    void setUp(@TempDir Path tempDir) throws IOException {
+        sourceDirectory = tempDir.resolve("templates");
+        targetDirectory = tempDir.resolve("generated");
+        Files.createDirectories(sourceDirectory);
+
+        main = new Main();
+        main.sourceDirectory = sourceDirectory;
+        main.targetDirectory = targetDirectory;
+    }
+
+    @Test
+    void generatesJavaSourceFromTemplate() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "@param String name\nHello, ${name}!");
+        main.contentType = ContentType.Plain;
+
+        int amount = main.run();
+
+        assertThat(amount).isEqualTo(1);
+        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
+        assertThat(generated).exists();
+        assertThat(Files.readString(generated)).contains("Hello, ");
+    }
+
+    @Test
+    void usesCustomPackageName() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "Hello!");
+        main.contentType = ContentType.Plain;
+        main.packageName = "com.example.templates";
+
+        main.run();
+
+        Path generated = targetDirectory.resolve("com/example/templates/JtehelloGenerated.java");
+        assertThat(generated).exists();
+        assertThat(Files.readString(generated)).contains("package com.example.templates;");
+    }
+
+    @Test
+    void trimsControlStructuresWhenEnabled() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "before\n@if(true)\nyes\n@endif\nafter");
+        main.contentType = ContentType.Plain;
+
+        main.run();
+        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
+        String untrimmed = Files.readString(generated);
+
+        main.trimControlStructures = true;
+        main.run();
+        String trimmed = Files.readString(generated);
+
+        assertThat(trimmed).isNotEqualTo(untrimmed);
+    }
+
+    @Test
+    void interceptsConfiguredHtmlTags() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "<form action=\"a\">\n</form>");
+        main.contentType = ContentType.Html;
+        main.htmlTags = new String[]{"form"};
+
+        main.run();
+
+        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
+        assertThat(Files.readString(generated)).contains("jteHtmlInterceptor.onHtmlTagOpened(\"form\"");
+    }
+
+    @Test
+    void preservesHtmlCommentsWhenEnabled() throws IOException {
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "<!--a comment-->");
+        main.contentType = ContentType.Html;
+        main.htmlCommentsPreserved = true;
+
+        main.run();
+
+        Path generated = targetDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.java");
+        assertThat(Files.readString(generated)).contains("a comment");
+    }
+
+    @Test
+    void generatesBinaryStaticContentToTargetResourceDirectory() throws IOException {
+        Path resourceDirectory = sourceDirectory.getParent().resolve("resources");
+        Files.writeString(sourceDirectory.resolve("hello.jte"), "Hello!");
+        main.contentType = ContentType.Plain;
+        main.binaryStaticContent = true;
+        main.targetResourceDirectory = resourceDirectory;
+
+        main.run();
+
+        Path resourceFile = resourceDirectory.resolve("gg/jte/generated/precompiled/JtehelloGenerated.bin");
+        assertThat(resourceFile).exists();
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
   - "Build Tools":
     - "Maven Plugin": maven-plugin.md
     - "Gradle Plugin": gradle-plugin.md
+    - "Command Line Interface": cli.md
   - "How To":
     - "Hot Reloading": hot-reloading.md
     - "Precompiling Templates": pre-compiling.md

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <module>jte-models</module>
         <module>jte-watcher</module>
         <module>jte-maven-plugin</module>
+        <module>jte-cli</module>
         <module>jte-jsp-converter</module>
         <module>jte-jsp-converter-jakarta</module>
         <module>jte-spring-boot-starter-2</module>


### PR DESCRIPTION
Address #488 by adding a CLI to generate code from templates without a build plugin.

To keep it small for an initial version:
* Java (.jte) templates only, not .kte. Otherwise it would need to shade in the Kotlin compiler or figure out adding it to the classpath another way.
* Extensions (e.g. jte-models) are not supported. Also awkward classpath dependencies.