### PR TITLE
make validate links run against a local build of docs

### DIFF
--- a/.github/workflows/validate-links.yml
+++ b/.github/workflows/validate-links.yml
@@ -7,6 +7,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v6
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - name: Setup MkDocs
+        run: .github/scripts/setup-docs-dependencies.sh
+      - name: Build docs
+        # Build the docs as they will look after the next release is published,
+        # so links to pages/anchors added in this commit can be remapped below
+        # instead of being checked against the still-unpublished live site.
+        run: mkdocs build --site-dir _site
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2
         with:
@@ -18,7 +35,8 @@ jobs:
             --exclude test.com
             --exclude maven.apache.org
             --exclude w3.org
-            --exclude "csp\.withgoogle\.com"'
+            --exclude "csp\.withgoogle\.com"
+            --remap "^https://jte\.gg file://$(pwd)/_site"'
           jobSummary: true
           format: markdown
           fail: true

--- a/.github/workflows/validate-links.yml
+++ b/.github/workflows/validate-links.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           args: '**/*.java **/*.md **/*.xml **/*.html **/*.yml
             --verbose --no-progress
+            --exclude-path _site
             --exclude localhost
             --exclude "github\.com/casid/jte/blob"
             --exclude "@template"


### PR DESCRIPTION
validate links runs against the published version of the documentation site. This means that links referring to newly added docs cause errors, because they haven't been published yet.

This change makes the workflow build a local version of the docs, and validate against that instead of the published version. It should avoid the problem.