### PR TITLE
Allow for content type overwrite in spring boot servlet views

### DIFF
--- a/jte-spring-boot-starter-4/src/main/java/gg/jte/springframework/boot/autoconfigure/JteView.java
+++ b/jte-spring-boot-starter-4/src/main/java/gg/jte/springframework/boot/autoconfigure/JteView.java
@@ -5,7 +5,6 @@ import gg.jte.output.PrintWriterOutput;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.jspecify.annotations.NonNull;
-import org.springframework.http.MediaType;
 import org.springframework.web.servlet.view.AbstractTemplateView;
 
 import java.nio.charset.StandardCharsets;
@@ -28,7 +27,6 @@ public class JteView extends AbstractTemplateView {
     @Override
     protected void renderMergedTemplateModel(@NonNull Map<String, Object> model, @NonNull HttpServletRequest request, HttpServletResponse response) throws Exception {
         String url = this.getUrl();
-        response.setContentType(MediaType.TEXT_HTML_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         PrintWriterOutput output = new PrintWriterOutput(response.getWriter());
         templateEngine.render(url, model, output);

--- a/jte-spring-boot-starter-4/src/test/java/gg/jte/springframework/boot/autoconfigure/reactive/JteSpringBootReactiveTestController.java
+++ b/jte-spring-boot-starter-4/src/test/java/gg/jte/springframework/boot/autoconfigure/reactive/JteSpringBootReactiveTestController.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.reactive.result.view.FragmentsRendering;
 
 @Controller
 public class JteSpringBootReactiveTestController {
@@ -12,5 +13,13 @@ public class JteSpringBootReactiveTestController {
     public String greeting(@RequestParam("subject") String subject, Model model) {
         model.addAttribute("subject", subject);
         return "greeting";
+    }
+
+    @GetMapping("/stream")
+    public FragmentsRendering stream(Model model) {
+        model.addAttribute("subject", "World");
+        return FragmentsRendering.fragment("greeting")
+                .build();
+
     }
 }

--- a/jte-spring-boot-starter-4/src/test/java/gg/jte/springframework/boot/autoconfigure/reactive/JteSpringBootReactiveTests.java
+++ b/jte-spring-boot-starter-4/src/test/java/gg/jte/springframework/boot/autoconfigure/reactive/JteSpringBootReactiveTests.java
@@ -28,4 +28,23 @@ public class JteSpringBootReactiveTests {
                         })
                 );
     }
+
+    // WebFlux forces text/html for FragmentsRendering fragments (see
+    // ViewResolutionResultHandler#renderFragment, which passes a hardcoded MediaType.TEXT_HTML),
+    // so a custom content type like text/vnd.turbo-streams.html cannot be produced on the reactive
+    // stack. This test documents that behavior; the turbo-streams content type is covered on the
+    // servlet stack in JteSpringBootServletTests#stream.
+    @Test
+    void stream(@Autowired WebTestClient client) throws Exception {
+        client.get()
+                .uri("/stream")
+                .exchange()
+                .expectAll(
+                        spec -> spec.expectStatus().isOk(),
+                        spec -> spec.expectHeader().contentType("text/html;charset=UTF-8"),
+                        spec -> spec.expectBody(String.class).value(v -> {
+                            assertThat(v).contains("Hello World!");
+                        })
+                );
+    }
 }

--- a/jte-spring-boot-starter-4/src/test/java/gg/jte/springframework/boot/autoconfigure/servlet/JteSpringBootServletTestController.java
+++ b/jte-spring-boot-starter-4/src/test/java/gg/jte/springframework/boot/autoconfigure/servlet/JteSpringBootServletTestController.java
@@ -1,9 +1,11 @@
 package gg.jte.springframework.boot.autoconfigure.servlet;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.view.FragmentsRendering;
 
 @Controller
 public class JteSpringBootServletTestController {
@@ -13,4 +15,14 @@ public class JteSpringBootServletTestController {
         model.addAttribute("subject", subject);
         return "greeting";
     }
+
+    @GetMapping(value = "/stream")
+    public FragmentsRendering stream(Model model) {
+        model.addAttribute("subject", "World");
+        return FragmentsRendering.fragment("greeting")
+                .header(HttpHeaders.CONTENT_TYPE, "text/vnd.turbo-streams.html")
+                .build();
+
+    }
+
 }

--- a/jte-spring-boot-starter-4/src/test/java/gg/jte/springframework/boot/autoconfigure/servlet/JteSpringBootServletTests.java
+++ b/jte-spring-boot-starter-4/src/test/java/gg/jte/springframework/boot/autoconfigure/servlet/JteSpringBootServletTests.java
@@ -26,4 +26,13 @@ public class JteSpringBootServletTests {
                 .andExpect(model().attribute("subject", "World"))
                 .andExpect(content().string(containsString("Hello World!")));
     }
+
+    @Test
+    void stream(@Autowired MockMvc mvc) throws Exception {
+        mvc.perform(get("/stream"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/vnd.turbo-streams.html;charset=UTF-8"))
+                .andExpect(model().attribute("subject", "World"))
+                .andExpect(content().string(containsString("Hello World!")));
+    }
 }


### PR DESCRIPTION
* Removed content type overwrite from JteView allowing for it to be set in the controller and added test pinning the behavior
* On the reactive side, I added a test but the view dispatch flow does not allow for content type to be overwritten, so I used the test to pin the behavior for posterity
* I confirmed this behavior matches what thymeleaf is doing as well.

AI disclosure: I used AI to analyze thymeleaf's codebase and compare their implementation with ours. 

Fixes #561